### PR TITLE
fix(fuse): allow access by non-mount users

### DIFF
--- a/src/dicfuse/tree_store.rs
+++ b/src/dicfuse/tree_store.rs
@@ -164,10 +164,7 @@ impl TreeStorage {
         let mut children = Vec::new();
         let inode = self.get_storage_item(inode)?;
         for child in inode.children {
-            match self.get_item(child) {
-                Ok(item) => children.push(item),
-                Err(e) => return Err(e),
-            }
+            children.push(self.get_item(child)?);
         }
         Ok(children)
     }

--- a/src/fuse/async_io.rs
+++ b/src/fuse/async_io.rs
@@ -57,7 +57,7 @@ impl Filesystem for MegaFuse {
     async fn destroy(&self, req: Request) {
         self.dic.destroy(req).await;
         let map_lock = &self.overlayfs.lock().await;
-        for (_, ovl_fs) in map_lock.iter() {
+        for ovl_fs in map_lock.values() {
             ovl_fs.destroy(req).await;
         }
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -128,8 +128,11 @@ pub async fn mount_filesystem_with_antares_cache<
     let gid = unsafe { libc::getgid() };
 
     let mut mount_options = MountOptions::default();
-    // .allow_other(true)
-    mount_options.force_readdir_plus(true).uid(uid).gid(gid);
+    mount_options
+        .allow_other(true)
+        .force_readdir_plus(true)
+        .uid(uid)
+        .gid(gid);
     if enable_antares_cache {
         apply_antares_cache_mount_options(&mut mount_options);
     }


### PR DESCRIPTION
## Summary
- enable `allow_other` together with the existing UID/GID mount mapping
- preserve `force_readdir_plus` and Antares cache behavior

## Why
When ScorpioFS is mounted by a privileged daemon but consumed by a different local user, the Linux FUSE default restricts access to the mount owner. This prevented the user running Buck2 from reading the Antares mount.

## Validation
- rebuilt and ran ScorpioFS with a root-owned Antares FUSE mount
- built the Mega changelist-backed target `//:aardvark-dns` as the consuming user
- Buck2 completed with `BUILD SUCCEEDED`

## Impact
This enables the daemon/client deployment model used by Antares. Systems using this option must permit `user_allow_other` in `/etc/fuse.conf`.
