### PR TITLE
feat(install): add interactive ScorpioFS installer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,4 +251,4 @@ jobs:
           sudo bash script/test_installer_systemd.sh \
             "${version}" \
             http://127.0.0.1:18080 \
-            "${RUNNER_TEMP}/scorpiofs-systemd-test"
+            "/tmp/scorpiofs-systemd-test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,14 +110,16 @@ jobs:
           custom_antares_state="${install_root}/data/custom-state/antares.toml"
           sudo install -d "${install_root}/data/custom-state"
           sudo sed -i \
-            -e "s|^config_file = .*|config_file = \"${custom_config}\"|" \
-            -e "s|^antares_state_file = .*|antares_state_file = \"${custom_antares_state}\"|" \
+            -e 's|^config_file = .*|config_file = "custom-state/scorpio.toml"|' \
+            -e 's|^antares_state_file = .*|antares_state_file = "custom-state/antares.toml"|' \
             "${install_root}/etc/scorpio.toml"
           sudo chown nobody:nogroup "${install_root}/etc/scorpio.toml"
           sudo install -m 0644 -o nobody -g nogroup /dev/null "${install_root}/data/config.toml"
           sudo install -m 0644 -o nobody -g nogroup /dev/null "${install_root}/data/antares/state.toml"
           sudo install -m 0644 -o nobody -g nogroup /dev/null "${custom_config}"
           sudo install -m 0644 -o nobody -g nogroup /dev/null "${custom_antares_state}"
+          sudo install -d -o nobody -g nogroup "${install_root}/data/store/content.db"
+          sudo install -m 0644 -o nobody -g nogroup /dev/null "${install_root}/data/store/content.db/LOCK"
 
           unrelated_root="${install_root}/unrelated-data"
           sudo install -d -o root -g root "${unrelated_root}"
@@ -158,6 +160,7 @@ jobs:
           test "$(stat -c '%U' "${install_root}/etc/scorpio.toml")" = "${USER}"
           test "$(stat -c '%U' "${custom_config}")" = "${USER}"
           test "$(stat -c '%U' "${custom_antares_state}")" = "${USER}"
+          test "$(stat -c '%U' "${install_root}/data/store/content.db/LOCK")" = "${USER}"
           test "$(stat -c '%U' "${install_root}/data/config.toml")" = nobody
           test "$(stat -c '%U' "${install_root}/data/antares/state.toml")" = nobody
           grep -F 'base_url = "https://mega.example.com"' "${install_root}/etc/scorpio.toml"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,10 @@ jobs:
       - name: Build release
         run: cargo build --release --verbose
 
+      - name: Test installer validation
+        if: matrix.rust == 'stable'
+        run: bash script/test_installer.sh
+
       - name: Exercise installer with local release
         if: matrix.rust == 'stable'
         run: |
@@ -80,7 +84,7 @@ jobs:
             sleep 0.25
           done
 
-          sudo bash install.sh \
+          sudo env 'SCORPIO_GIT_AUTHOR=DOMAIN\Bob "Builder"' bash install.sh \
             --version "${version}" \
             --release-base-url http://127.0.0.1:18080 \
             --non-interactive \
@@ -100,3 +104,46 @@ jobs:
           "${install_root}/prefix/bin/antares" --version
           "${install_root}/prefix/bin/scorpio" \
             --config-path "${install_root}/etc/scorpio.toml" config validate
+          grep -F 'git_author = "DOMAIN\\Bob \"Builder\""' "${install_root}/etc/scorpio.toml"
+
+          sudo chown nobody:nogroup "${install_root}/etc/scorpio.toml"
+          sudo bash install.sh \
+            --version "${version}" \
+            --release-base-url http://127.0.0.1:18080 \
+            --non-interactive \
+            --no-deps \
+            --no-service \
+            --no-user-allow-other \
+            --base-url https://ignored.example.com \
+            --lfs-url https://ignored.example.com/lfs \
+            --prefix "${install_root}/prefix" \
+            --config-dir "${install_root}/etc" \
+            --data-root "${install_root}/data" \
+            --workspace "${install_root}/data/mount" \
+            --store-path "${install_root}/data/store" \
+            --http-addr 127.0.0.1:2825
+          test "$(stat -c '%U' "${install_root}/etc/scorpio.toml")" = "${USER}"
+          grep -F 'base_url = "https://mega.example.com"' "${install_root}/etc/scorpio.toml"
+
+          sudo bash install.sh \
+            --version "${version}" \
+            --release-base-url http://127.0.0.1:18080 \
+            --non-interactive \
+            --overwrite-config \
+            --no-deps \
+            --no-service \
+            --no-user-allow-other \
+            --base-url https://new-mega.example.com \
+            --lfs-url https://new-mega.example.com/lfs \
+            --prefix "${install_root}/prefix" \
+            --config-dir "${install_root}/etc" \
+            --data-root "${install_root}/data" \
+            --workspace "${install_root}/data/mount" \
+            --store-path "${install_root}/data/store" \
+            --http-addr 127.0.0.1:2825
+          grep -F 'base_url = "https://new-mega.example.com"' "${install_root}/etc/scorpio.toml"
+
+          sudo bash script/test_installer_systemd.sh \
+            "${version}" \
+            http://127.0.0.1:18080 \
+            "${RUNNER_TEMP}/scorpiofs-systemd-test"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,6 +165,27 @@ jobs:
           test "$(stat -c '%U' "${install_root}/data/antares/state.toml")" = nobody
           grep -F 'base_url = "https://mega.example.com"' "${install_root}/etc/scorpio.toml"
 
+          printf '%s\n' 'load_dir_depth = "invalid"' | \
+            sudo tee -a "${install_root}/etc/scorpio.toml" >/dev/null
+          if sudo env SCORPIO_LOAD_DIR_DEPTH=3 bash install.sh \
+            --version "${version}" \
+            --release-base-url http://127.0.0.1:18080 \
+            --non-interactive \
+            --no-deps \
+            --no-service \
+            --no-user-allow-other \
+            --base-url https://ignored.example.com \
+            --lfs-url https://ignored.example.com/lfs \
+            --prefix "${install_root}/prefix" \
+            --config-dir "${install_root}/etc" \
+            --http-addr 127.0.0.1:2825 >"${RUNNER_TEMP}/config-env-override.log" 2>&1; then
+            echo "installer accepted an invalid retained config through an environment override" >&2
+            exit 1
+          fi
+          grep -F 'could not safely resolve runtime paths from retained config' \
+            "${RUNNER_TEMP}/config-env-override.log"
+          sudo sed -i '/^load_dir_depth = "invalid"$/d' "${install_root}/etc/scorpio.toml"
+
           sudo bash install.sh \
             --version "${version}" \
             --release-base-url http://127.0.0.1:18080 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,3 +50,53 @@ jobs:
       
       - name: Build release
         run: cargo build --release --verbose
+
+      - name: Exercise installer with local release
+        if: matrix.rust == 'stable'
+        run: |
+          set -euo pipefail
+          version="v0.0.0-local"
+          target="x86_64-unknown-linux-gnu"
+          asset_root="${RUNNER_TEMP}/scorpiofs-installer-assets"
+          dist="scorpiofs-${version}-${target}"
+          install_root="${RUNNER_TEMP}/scorpiofs-installed"
+
+          mkdir -p "${asset_root}/${version}/${dist}"
+          cp target/release/scorpio target/release/antares "${asset_root}/${version}/${dist}/"
+          tar -C "${asset_root}/${version}" -czf "${asset_root}/${version}/${dist}.tar.gz" "${dist}"
+          (
+            cd "${asset_root}/${version}"
+            sha256sum "${dist}.tar.gz" > "${dist}.tar.gz.sha256"
+          )
+
+          python3 -m http.server 18080 --bind 127.0.0.1 --directory "${asset_root}" \
+            >"${RUNNER_TEMP}/scorpiofs-installer-http.log" 2>&1 &
+          server_pid=$!
+          trap 'kill "${server_pid}" 2>/dev/null || true' EXIT
+          for _ in {1..20}; do
+            if curl -fsS "http://127.0.0.1:18080/${version}/${dist}.tar.gz.sha256" >/dev/null; then
+              break
+            fi
+            sleep 0.25
+          done
+
+          sudo bash install.sh \
+            --version "${version}" \
+            --release-base-url http://127.0.0.1:18080 \
+            --non-interactive \
+            --no-deps \
+            --no-service \
+            --no-user-allow-other \
+            --base-url https://mega.example.com \
+            --lfs-url https://mega.example.com/lfs \
+            --prefix "${install_root}/prefix" \
+            --config-dir "${install_root}/etc" \
+            --data-root "${install_root}/data" \
+            --workspace "${install_root}/data/mount" \
+            --store-path "${install_root}/data/store" \
+            --http-addr 127.0.0.1:2825
+
+          "${install_root}/prefix/bin/scorpio" --version
+          "${install_root}/prefix/bin/antares" --version
+          "${install_root}/prefix/bin/scorpio" \
+            --config-path "${install_root}/etc/scorpio.toml" config validate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
             --non-interactive \
             --no-deps \
             --no-service \
-            --no-user-allow-other \
+            --enable-user-allow-other \
             --base-url https://mega.example.com \
             --lfs-url https://mega.example.com/lfs \
             --prefix "${install_root}/prefix" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,8 @@ jobs:
           grep -F 'git_author = "DOMAIN\\Bob \"Builder\""' "${install_root}/etc/scorpio.toml"
 
           sudo chown nobody:nogroup "${install_root}/etc/scorpio.toml"
+          sudo install -m 0644 -o nobody -g nogroup /dev/null "${install_root}/data/config.toml"
+          sudo install -m 0644 -o nobody -g nogroup /dev/null "${install_root}/data/antares/state.toml"
           sudo bash install.sh \
             --version "${version}" \
             --release-base-url http://127.0.0.1:18080 \
@@ -123,6 +125,8 @@ jobs:
             --store-path "${install_root}/data/store" \
             --http-addr 127.0.0.1:2825
           test "$(stat -c '%U' "${install_root}/etc/scorpio.toml")" = "${USER}"
+          test "$(stat -c '%U' "${install_root}/data/config.toml")" = "${USER}"
+          test "$(stat -c '%U' "${install_root}/data/antares/state.toml")" = "${USER}"
           grep -F 'base_url = "https://mega.example.com"' "${install_root}/etc/scorpio.toml"
 
           sudo bash install.sh \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,9 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    # Match the oldest supported GNU release baseline so PR builds catch
+    # accidental dependencies on newer glibc versions before a tag is cut.
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         rust: [stable, beta]
@@ -41,7 +43,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: target
-          key: ${{ runner.os }}-${{ matrix.rust }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-ubuntu-22.04-${{ matrix.rust }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
       
       - name: Build debug
         run: cargo build --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,9 +106,43 @@ jobs:
             --config-path "${install_root}/etc/scorpio.toml" config validate
           grep -F 'git_author = "DOMAIN\\Bob \"Builder\""' "${install_root}/etc/scorpio.toml"
 
+          custom_config="${install_root}/data/custom-state/scorpio.toml"
+          custom_antares_state="${install_root}/data/custom-state/antares.toml"
+          sudo install -d "${install_root}/data/custom-state"
+          sudo sed -i \
+            -e "s|^config_file = .*|config_file = \"${custom_config}\"|" \
+            -e "s|^antares_state_file = .*|antares_state_file = \"${custom_antares_state}\"|" \
+            "${install_root}/etc/scorpio.toml"
           sudo chown nobody:nogroup "${install_root}/etc/scorpio.toml"
           sudo install -m 0644 -o nobody -g nogroup /dev/null "${install_root}/data/config.toml"
           sudo install -m 0644 -o nobody -g nogroup /dev/null "${install_root}/data/antares/state.toml"
+          sudo install -m 0644 -o nobody -g nogroup /dev/null "${custom_config}"
+          sudo install -m 0644 -o nobody -g nogroup /dev/null "${custom_antares_state}"
+
+          unrelated_root="${install_root}/unrelated-data"
+          sudo install -d -o root -g root "${unrelated_root}"
+          sudo touch "${unrelated_root}/unrelated-file"
+          if sudo bash install.sh \
+            --version "${version}" \
+            --release-base-url http://127.0.0.1:18080 \
+            --non-interactive \
+            --no-deps \
+            --no-service \
+            --no-user-allow-other \
+            --base-url https://ignored.example.com \
+            --lfs-url https://ignored.example.com/lfs \
+            --prefix "${install_root}/prefix" \
+            --config-dir "${install_root}/etc" \
+            --data-root "${unrelated_root}" \
+            --workspace "${unrelated_root}/mount" \
+            --store-path "${unrelated_root}/store" \
+            --http-addr 127.0.0.1:2825 >"${RUNNER_TEMP}/unrelated-root.log" 2>&1; then
+            echo "installer accepted an unrelated nonempty data root" >&2
+            exit 1
+          fi
+          grep -F 'must be inside data-root' "${RUNNER_TEMP}/unrelated-root.log"
+          test "$(stat -c '%U' "${unrelated_root}")" = root
+
           sudo bash install.sh \
             --version "${version}" \
             --release-base-url http://127.0.0.1:18080 \
@@ -120,13 +154,12 @@ jobs:
             --lfs-url https://ignored.example.com/lfs \
             --prefix "${install_root}/prefix" \
             --config-dir "${install_root}/etc" \
-            --data-root "${install_root}/data" \
-            --workspace "${install_root}/data/mount" \
-            --store-path "${install_root}/data/store" \
             --http-addr 127.0.0.1:2825
           test "$(stat -c '%U' "${install_root}/etc/scorpio.toml")" = "${USER}"
-          test "$(stat -c '%U' "${install_root}/data/config.toml")" = "${USER}"
-          test "$(stat -c '%U' "${install_root}/data/antares/state.toml")" = "${USER}"
+          test "$(stat -c '%U' "${custom_config}")" = "${USER}"
+          test "$(stat -c '%U' "${custom_antares_state}")" = "${USER}"
+          test "$(stat -c '%U' "${install_root}/data/config.toml")" = nobody
+          test "$(stat -c '%U' "${install_root}/data/antares/state.toml")" = nobody
           grep -F 'base_url = "https://mega.example.com"' "${install_root}/etc/scorpio.toml"
 
           sudo bash install.sh \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
           sudo install -d -o nobody -g nogroup "${install_root}/data/store/content.db"
           sudo install -m 0644 -o nobody -g nogroup /dev/null "${install_root}/data/store/content.db/LOCK"
 
-          sudo bash install.sh \
+          bash install.sh \
             --version "${version}" \
             --release-base-url http://127.0.0.1:18080 \
             --non-interactive \
@@ -140,6 +140,30 @@ jobs:
             "${RUNNER_TEMP}/retained-dry-run.log"
           grep -F "[dry-run] chown -R -h -P ${USER}:${USER}" \
             "${RUNNER_TEMP}/retained-dry-run.log"
+
+          sudo sed -i \
+            "s|^workspace = .*|workspace = \"${install_root}/data/store\"|" \
+            "${install_root}/etc/scorpio.toml"
+          if bash install.sh \
+            --version "${version}" \
+            --release-base-url http://127.0.0.1:18080 \
+            --non-interactive \
+            --dry-run \
+            --no-deps \
+            --no-service \
+            --no-user-allow-other \
+            --base-url https://ignored.example.com \
+            --lfs-url https://ignored.example.com/lfs \
+            --prefix "${install_root}/prefix" \
+            --config-dir "${install_root}/etc" \
+            --http-addr 127.0.0.1:2825 >"${RUNNER_TEMP}/overlap-path.log" 2>&1; then
+            echo "installer accepted overlapping retained workspace/store paths" >&2
+            exit 1
+          fi
+          grep -F 'workspace must not overlap store-path' "${RUNNER_TEMP}/overlap-path.log"
+          sudo sed -i \
+            "s|^workspace = .*|workspace = \"${install_root}/data/mount\"|" \
+            "${install_root}/etc/scorpio.toml"
 
           unrelated_root="${install_root}/unrelated-data"
           sudo install -d -o root -g root "${unrelated_root}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,26 @@ jobs:
           sudo install -d -o nobody -g nogroup "${install_root}/data/store/content.db"
           sudo install -m 0644 -o nobody -g nogroup /dev/null "${install_root}/data/store/content.db/LOCK"
 
+          sudo bash install.sh \
+            --version "${version}" \
+            --release-base-url http://127.0.0.1:18080 \
+            --non-interactive \
+            --dry-run \
+            --no-deps \
+            --no-service \
+            --no-user-allow-other \
+            --base-url https://ignored.example.com \
+            --lfs-url https://ignored.example.com/lfs \
+            --prefix "${install_root}/prefix" \
+            --config-dir "${install_root}/etc" \
+            --http-addr 127.0.0.1:2825 >"${RUNNER_TEMP}/retained-dry-run.log"
+          grep -F "using data-root inferred from retained config: ${install_root}/data" \
+            "${RUNNER_TEMP}/retained-dry-run.log"
+          grep -F "using runtime paths from retained ${install_root}/etc/scorpio.toml" \
+            "${RUNNER_TEMP}/retained-dry-run.log"
+          grep -F "[dry-run] chown -R -h -P ${USER}:${USER}" \
+            "${RUNNER_TEMP}/retained-dry-run.log"
+
           unrelated_root="${install_root}/unrelated-data"
           sudo install -d -o root -g root "${unrelated_root}"
           sudo touch "${unrelated_root}/unrelated-file"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ permissions:
 jobs:
   build:
     name: build ${{ matrix.target }}
-    runs-on: ubuntu-latest
+    # Keep GNU release binaries compatible with Ubuntu 22.04 (glibc 2.35).
+    # Building on ubuntu-latest can silently raise the minimum glibc version.
+    runs-on: ubuntu-22.04
     # aarch64 (musl) is best-effort; a failure there must not block the x86_64 release.
     continue-on-error: ${{ matrix.best_effort }}
     strategy:

--- a/README.md
+++ b/README.md
@@ -279,7 +279,10 @@ Non-loopback HTTP binds require the explicit `--allow-public-api` flag and
 must be protected by a firewall or an authenticating reverse proxy. The script
 never edits `/etc/fuse.conf` unless the interactive prompt is accepted or
 `--enable-user-allow-other` is passed. `--uninstall` removes binaries and the
-unit but keeps configuration and data.
+unit but keeps configuration and data. Mirrors and locally packaged builds can
+be tested with `--release-base-url <url>` or `SCORPIO_RELEASE_BASE_URL`; the
+mirror layout is `<base>/<version>/scorpiofs-<version>-<target>.tar.gz` plus its
+`.sha256` file.
 
 Pushing a `v*` tag runs [`.github/workflows/release.yml`](.github/workflows/release.yml),
 which builds the binaries, produces `scorpiofs-<version>-<target>.tar.gz` +

--- a/README.md
+++ b/README.md
@@ -302,8 +302,10 @@ directories. Installed binaries and the main config must remain outside the
 FUSE workspace and Antares mount roots. Git author/email values may contain
 tabs, but other TOML control characters are rejected in every generated string.
 Inaccessible stale FUSE mounts are lazily detached before directory preparation;
-active mount roots are left unchanged. Retained upgrades resolve relative
-runtime paths against the data root and migrate persistent store/overlay
+non-FUSE mounts at configured mount roots are rejected and never detached.
+Service setup also rejects an accessible mount when no managed unit owns it:
+stop the user-run daemon and unmount it before retrying. Retained upgrades resolve
+relative runtime paths against the data root and migrate persistent store/overlay
 ownership after rejecting nested mounts; `--no-service` preserves the configured
 user of an existing unit.
 Service setup fails before installation when systemd is unavailable. Retained
@@ -311,9 +313,10 @@ config validation ignores ambient `SCORPIO_*` overrides so it matches the unit's
 runtime environment; a retained-config `--dry-run` uses the installed binary to
 resolve the same paths as a real upgrade, requesting sudo only when its protected
 config needs read access. Mount roots may not overlap persistent runtime paths.
-Active services are stopped before a
-service-user ownership migration and started under the new account. Mirrors and
-locally packaged builds can
+Managed active services are stopped before the binary, config, or unit is
+replaced. Any old configured FUSE roots left mounted after that stop are cleaned
+before the upgraded service starts, including when `--overwrite-config` changes
+a mount path. Mirrors and locally packaged builds can
 be tested with `--release-base-url <url>` or `SCORPIO_RELEASE_BASE_URL`; the
 mirror layout is `<base>/<version>/scorpiofs-<version>-<target>.tar.gz` plus its
 `.sha256` file.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ https://crates.io/crates/scorpiofs
 
 ### How to Use?
 
-**Prerequisites:** Linux with FUSE enabled, `libfuse-dev`, and a running Mega/monorepo server. See [docs/develop.md](docs/develop.md) for system setup (may require `sudo` for FUSE).
+**Prerequisites:** Linux with FUSE enabled, the FUSE 3 development library
+(`libfuse3-dev` on Ubuntu), and a running Mega/monorepo server. See
+[docs/develop.md](docs/develop.md) for system setup (may require `sudo` for
+FUSE).
 
 1. Start the mono server (e.g. `http://localhost:8000`).
 2. Edit **`scorpio.toml`** (not `config.toml`): set `base_url`, `workspace`, and `store_path`. The `config.toml` file is a **runtime state file** (tracks mounted workspaces), created automatically on first run.

--- a/README.md
+++ b/README.md
@@ -304,7 +304,9 @@ mounts; `--no-service` preserves the configured user of an existing unit.
 Service setup fails before installation when systemd is unavailable. Retained
 config validation ignores ambient `SCORPIO_*` overrides so it matches the unit's
 runtime environment; a retained-config `--dry-run` uses the installed binary to
-resolve the same paths as a real upgrade. Active services are stopped before a
+resolve the same paths as a real upgrade, requesting sudo only when its protected
+config needs read access. Mount roots may not overlap persistent runtime paths.
+Active services are stopped before a
 service-user ownership migration and started under the new account. Mirrors and
 locally packaged builds can
 be tested with `--release-base-url <url>` or `SCORPIO_RELEASE_BASE_URL`; the

--- a/README.md
+++ b/README.md
@@ -318,7 +318,9 @@ config needs read access. Mount roots may not overlap persistent runtime paths.
 Managed active services are stopped before the binary, config, or unit is
 replaced. Any old configured FUSE roots left mounted after that stop are cleaned
 before the upgraded service starts, including when `--overwrite-config` changes
-a mount path. Mirrors and locally packaged builds can
+a mount path or migrates to a new data root. An all-relative old config cannot
+be migrated to an empty new root until its old mounts are manually unmounted.
+Mirrors and locally packaged builds can
 be tested with `--release-base-url <url>` or `SCORPIO_RELEASE_BASE_URL`; the
 mirror layout is `<base>/<version>/scorpiofs-<version>-<target>.tar.gz` plus its
 `.sha256` file.

--- a/README.md
+++ b/README.md
@@ -299,8 +299,11 @@ never edits `/etc/fuse.conf` unless the interactive prompt is accepted or
 unit but keeps configuration and data. `--workspace` and `--store-path` must be
 inside the dedicated `--data-root`, preventing ownership changes to broad host
 directories. Retained upgrades resolve relative runtime paths against the data
-root and migrate persistent store/overlay ownership; `--no-service` preserves
-the configured user of an existing unit. Mirrors and locally packaged builds can
+root and migrate persistent store/overlay ownership after rejecting nested
+mounts; `--no-service` preserves the configured user of an existing unit.
+Service setup fails before installation when systemd is unavailable. Retained
+config validation ignores ambient `SCORPIO_*` overrides so it matches the unit's
+runtime environment. Mirrors and locally packaged builds can
 be tested with `--release-base-url <url>` or `SCORPIO_RELEASE_BASE_URL`; the
 mirror layout is `<base>/<version>/scorpiofs-<version>-<target>.tar.gz` plus its
 `.sha256` file.

--- a/README.md
+++ b/README.md
@@ -261,15 +261,25 @@ docker run --rm --device /dev/fuse --cap-add SYS_ADMIN \
 (`Type=simple`, `AmbientCapabilities=CAP_SYS_ADMIN`, `TimeoutStopSec=45`,
 loopback bind by default, journald logging).
 
-**install.sh** — [`install.sh`](install.sh) downloads a release tarball,
-**verifies its SHA256 checksum**, and installs the binaries + a generated config.
-It supports `--dry-run`, `--uninstall`, and never edits `/etc/fuse.conf` unless
-you pass `--enable-user-allow-other`:
+**install.sh** — [`install.sh`](install.sh) is an interactive installer. It
+asks for `base_url`, `lfs_url`, local paths, the HTTP bind address, FUSE
+permissions, and whether to create a systemd service. It downloads a release
+tarball, **verifies its SHA256 checksum**, creates the dedicated `scorpiofs`
+service user, and generates a config with absolute runtime paths. The HTTP API
+defaults to loopback because it has no authentication:
 
 ```bash
-bash install.sh --version v0.3.0 --dry-run   # preview
-sudo bash install.sh --version v0.3.0        # install
+bash install.sh                               # interactive
+bash install.sh --version v0.4.0 --dry-run    # preview
+sudo bash install.sh --version v0.4.0         # install
 ```
+
+For automation, use `--non-interactive` with `--base-url` and `--lfs-url`.
+Non-loopback HTTP binds require the explicit `--allow-public-api` flag and
+must be protected by a firewall or an authenticating reverse proxy. The script
+never edits `/etc/fuse.conf` unless the interactive prompt is accepted or
+`--enable-user-allow-other` is passed. `--uninstall` removes binaries and the
+unit but keeps configuration and data.
 
 Pushing a `v*` tag runs [`.github/workflows/release.yml`](.github/workflows/release.yml),
 which builds the binaries, produces `scorpiofs-<version>-<target>.tar.gz` +

--- a/README.md
+++ b/README.md
@@ -307,7 +307,9 @@ Service setup also rejects an accessible mount when no managed unit owns it:
 stop the user-run daemon and unmount it before retrying. Retained upgrades resolve
 relative runtime paths against the data root and migrate persistent store/overlay
 ownership after rejecting nested mounts; `--no-service` preserves the configured
-user of an existing unit.
+user of an existing unit. Non-root installs use elevated lookup when the config
+directory is not searchable, so a protected existing config is still retained
+unless `--overwrite-config` is explicit.
 Service setup fails before installation when systemd is unavailable. Retained
 config validation ignores ambient `SCORPIO_*` overrides so it matches the unit's
 runtime environment; a retained-config `--dry-run` uses the installed binary to

--- a/README.md
+++ b/README.md
@@ -300,10 +300,12 @@ unit but keeps configuration and data. `--workspace` and `--store-path` must be
 inside the dedicated `--data-root`, preventing ownership changes to broad host
 directories. Installed binaries and the main config must remain outside the
 FUSE workspace and Antares mount roots. Git author/email values may contain
-tabs, but other TOML control characters are rejected. Retained upgrades resolve
-relative runtime paths against the data root and migrate persistent
-store/overlay ownership after rejecting nested mounts; `--no-service` preserves
-the configured user of an existing unit.
+tabs, but other TOML control characters are rejected in every generated string.
+Inaccessible stale FUSE mounts are lazily detached before directory preparation;
+active mount roots are left unchanged. Retained upgrades resolve relative
+runtime paths against the data root and migrate persistent store/overlay
+ownership after rejecting nested mounts; `--no-service` preserves the configured
+user of an existing unit.
 Service setup fails before installation when systemd is unavailable. Retained
 config validation ignores ambient `SCORPIO_*` overrides so it matches the unit's
 runtime environment; a retained-config `--dry-run` uses the installed binary to

--- a/README.md
+++ b/README.md
@@ -272,17 +272,33 @@ service user, and generates a config with absolute runtime paths. The HTTP API
 defaults to loopback because it has no authentication:
 
 ```bash
-bash install.sh                               # interactive
-bash install.sh --version v0.4.0 --dry-run    # preview
-sudo bash install.sh --version v0.4.0         # install
+# Recommended: download, inspect, then run interactively.
+curl -fsSLO https://raw.githubusercontent.com/gitmono-dev/scorpiofs/main/install.sh
+less install.sh
+sudo bash install.sh
+
+# One-line interactive install.
+curl -fsSL https://raw.githubusercontent.com/gitmono-dev/scorpiofs/main/install.sh | sudo bash
 ```
 
-For automation, use `--non-interactive` with `--base-url` and `--lfs-url`.
+The installer resolves the latest release by default. For automation, pass
+arguments after `bash -s --`; use `--overwrite-config` only when the supplied
+values should replace an existing installation:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/gitmono-dev/scorpiofs/main/install.sh | \
+  sudo bash -s -- --non-interactive --overwrite-config \
+    --base-url https://mega.example.com \
+    --lfs-url https://mega.example.com/lfs
+```
+
 Non-loopback HTTP binds require the explicit `--allow-public-api` flag and
 must be protected by a firewall or an authenticating reverse proxy. The script
 never edits `/etc/fuse.conf` unless the interactive prompt is accepted or
 `--enable-user-allow-other` is passed. `--uninstall` removes binaries and the
-unit but keeps configuration and data. Mirrors and locally packaged builds can
+unit but keeps configuration and data. `--workspace` and `--store-path` must be
+inside the dedicated `--data-root`, preventing ownership changes to broad host
+directories. Mirrors and locally packaged builds can
 be tested with `--release-base-url <url>` or `SCORPIO_RELEASE_BASE_URL`; the
 mirror layout is `<base>/<version>/scorpiofs-<version>-<target>.tar.gz` plus its
 `.sha256` file.

--- a/README.md
+++ b/README.md
@@ -295,7 +295,10 @@ curl -fsSL https://raw.githubusercontent.com/gitmono-dev/scorpiofs/main/install.
 Non-loopback HTTP binds require the explicit `--allow-public-api` flag and
 must be protected by a firewall or an authenticating reverse proxy. The script
 never edits `/etc/fuse.conf` unless the interactive prompt is accepted or
-`--enable-user-allow-other` is passed. `--uninstall` removes binaries and the
+`--enable-user-allow-other` is passed. Because ScorpioFS uses `allow_other`
+FUSE mounts, an installation that declines the change is accepted only when
+`/etc/fuse.conf` already contains `user_allow_other`; otherwise the installer
+stops with an actionable error. `--uninstall` removes binaries and the
 unit but keeps configuration and data. `--workspace` and `--store-path` must be
 inside the dedicated `--data-root`, preventing ownership changes to broad host
 directories. Installed binaries and the main config must remain outside the

--- a/README.md
+++ b/README.md
@@ -298,7 +298,9 @@ never edits `/etc/fuse.conf` unless the interactive prompt is accepted or
 `--enable-user-allow-other` is passed. `--uninstall` removes binaries and the
 unit but keeps configuration and data. `--workspace` and `--store-path` must be
 inside the dedicated `--data-root`, preventing ownership changes to broad host
-directories. Mirrors and locally packaged builds can
+directories. Retained upgrades resolve relative runtime paths against the data
+root and migrate persistent store/overlay ownership; `--no-service` preserves
+the configured user of an existing unit. Mirrors and locally packaged builds can
 be tested with `--release-base-url <url>` or `SCORPIO_RELEASE_BASE_URL`; the
 mirror layout is `<base>/<version>/scorpiofs-<version>-<target>.tar.gz` plus its
 `.sha256` file.

--- a/README.md
+++ b/README.md
@@ -298,9 +298,12 @@ never edits `/etc/fuse.conf` unless the interactive prompt is accepted or
 `--enable-user-allow-other` is passed. `--uninstall` removes binaries and the
 unit but keeps configuration and data. `--workspace` and `--store-path` must be
 inside the dedicated `--data-root`, preventing ownership changes to broad host
-directories. Retained upgrades resolve relative runtime paths against the data
-root and migrate persistent store/overlay ownership after rejecting nested
-mounts; `--no-service` preserves the configured user of an existing unit.
+directories. Installed binaries and the main config must remain outside the
+FUSE workspace and Antares mount roots. Git author/email values may contain
+tabs, but other TOML control characters are rejected. Retained upgrades resolve
+relative runtime paths against the data root and migrate persistent
+store/overlay ownership after rejecting nested mounts; `--no-service` preserves
+the configured user of an existing unit.
 Service setup fails before installation when systemd is unavailable. Retained
 config validation ignores ambient `SCORPIO_*` overrides so it matches the unit's
 runtime environment; a retained-config `--dry-run` uses the installed binary to

--- a/README.md
+++ b/README.md
@@ -303,7 +303,10 @@ root and migrate persistent store/overlay ownership after rejecting nested
 mounts; `--no-service` preserves the configured user of an existing unit.
 Service setup fails before installation when systemd is unavailable. Retained
 config validation ignores ambient `SCORPIO_*` overrides so it matches the unit's
-runtime environment. Mirrors and locally packaged builds can
+runtime environment; a retained-config `--dry-run` uses the installed binary to
+resolve the same paths as a real upgrade. Active services are stopped before a
+service-user ownership migration and started under the new account. Mirrors and
+locally packaged builds can
 be tested with `--release-base-url <url>` or `SCORPIO_RELEASE_BASE_URL`; the
 mirror layout is `<base>/<version>/scorpiofs-<version>-<target>.tar.gz` plus its
 `.sha256` file.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -144,7 +144,13 @@ generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
   place.
 - `--overwrite-config` (or `SCORPIO_OVERWRITE_CONFIG=1`) is required when an
   automated upgrade should replace an existing `scorpio.toml`; otherwise its
-  contents are retained while ownership is reconciled with the service user.
+  contents are retained. Relative runtime paths in retained configs are resolved
+  against the explicit or inferred data root.
+- Retained upgrades recursively reconcile ownership for the local store and
+  Antares upper/CL data. FUSE workspace and mount roots are not traversed.
+- On an existing systemd installation, `--no-service` leaves the unit untouched
+  and preserves ownership for its configured `User` rather than reassigning the
+  config and data to the invoking sudo user.
 - `--workspace` and `--store-path` must be children of the dedicated
   `--data-root`; filesystem roots, symlink escapes, shell metacharacters, and
   nonempty directories without an existing ScorpioFS config are rejected.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -146,7 +146,8 @@ generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
   automated upgrade should replace an existing `scorpio.toml`; otherwise its
   contents are retained while ownership is reconciled with the service user.
 - `--workspace` and `--store-path` must be children of the dedicated
-  `--data-root`; filesystem roots and broad system directories are rejected.
+  `--data-root`; filesystem roots, symlink escapes, shell metacharacters, and
+  nonempty directories without an existing ScorpioFS config are rejected.
 - `--release-base-url` (or `SCORPIO_RELEASE_BASE_URL`) points the installer at
   a mirror or local HTTP server using the same `<base>/<version>/<asset>`
   layout as GitHub releases. The PR build uses this to exercise a complete

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -163,7 +163,9 @@ generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
 - A retained-config `--dry-run` resolves effective paths with the already
   installed `scorpio` binary. It fails explicitly when that binary is missing,
   because the preview could not otherwise validate the real upgrade paths. A
-  non-root preview may request sudo only to read a protected mode-0640 config.
+  non-root preview may request sudo to detect and read a protected config;
+  real non-root installs use the same elevated existence check rather than
+  treating an unsearchable config directory as an absent configuration.
 - `--workspace` and `--store-path` must be children of the dedicated
   `--data-root`; filesystem roots, symlink escapes, shell metacharacters, and
   nonempty directories without an existing ScorpioFS config are rejected.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -162,10 +162,14 @@ generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
   retained file is validated exactly as the generated systemd unit will load it.
 - A retained-config `--dry-run` resolves effective paths with the already
   installed `scorpio` binary. It fails explicitly when that binary is missing,
-  because the preview could not otherwise validate the real upgrade paths.
+  because the preview could not otherwise validate the real upgrade paths. A
+  non-root preview may request sudo only to read a protected mode-0640 config.
 - `--workspace` and `--store-path` must be children of the dedicated
   `--data-root`; filesystem roots, symlink escapes, shell metacharacters, and
   nonempty directories without an existing ScorpioFS config are rejected.
+- FUSE workspace/Antares mount roots must not equal, contain, or sit inside
+  persistent store, config, upper, CL, or state paths; mount roots also may not
+  overlap each other.
 - `--release-base-url` (or `SCORPIO_RELEASE_BASE_URL`) points the installer at
   a mirror or local HTTP server using the same `<base>/<version>/<asset>`
   layout as GitHub releases. The PR build uses this to exercise a complete

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -172,7 +172,10 @@ generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
   overlap each other. Installed binaries and the main `scorpio.toml` must also
   remain outside both mount roots.
 - Git author/email values may contain tabs, which are escaped in TOML; other
-  control characters are rejected before installation begins.
+  control characters are rejected from every generated TOML string before
+  installation begins.
+- Inaccessible stale FUSE workspace/Antares mounts are lazily detached before
+  directory preparation; accessible active mount roots are not chowned.
 - `--release-base-url` (or `SCORPIO_RELEASE_BASE_URL`) points the installer at
   a mirror or local HTTP server using the same `<base>/<version>/<asset>`
   layout as GitHub releases. The PR build uses this to exercise a complete

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -135,9 +135,10 @@ generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
 
 When a systemd service is selected, the installer waits for the configured
 `/health` endpoint before reporting success. During an upgrade, a failure after
-stopping the existing service triggers a best-effort service restart. Existing
-data-directory permissions are preserved; only newly created directories use
-the installer's default `0755` mode.
+stopping the existing service restores the previous binaries, config, and unit
+before attempting to restart it. Existing data-directory permissions are
+preserved; only newly created directories use the installer's default `0755`
+mode.
 
 - Run `sudo bash install.sh` for the interactive flow. It supports `curl | bash`
   because prompts are read from a verified controlling terminal.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -163,7 +163,11 @@ Pushing a `v*` tag triggers `.github/workflows/release.yml`, which:
 - creates a GitHub Release with all artifacts attached.
 
 `install.sh` downloads the per-target tarball **and its `.sha256`**, then runs
-`sha256sum -c` and refuses to install on mismatch.
+`sha256sum -c` and refuses to install on mismatch. Before replacing installed
+binaries, it also runs both extracted binaries with `--version`; this catches
+CPU, dynamic-linker, and glibc incompatibilities without leaving a broken
+installation behind. GNU release binaries are built on Ubuntu 22.04 to retain
+glibc 2.35 compatibility.
 
 Publishing to **crates.io is decoupled** from the binary release: the
 `publish-crate` job targets a protected GitHub Environment (`crates-io`).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -11,6 +11,8 @@ need:
 
 - the `fuse` kernel module loaded and the `/dev/fuse` device present;
 - the `fuse3` userspace package (provides the setuid `fusermount3` helper);
+- `findmnt` from `util-linux`, used to prevent ownership migration across nested
+  mounts during upgrades;
 - permission to mount — either `CAP_SYS_ADMIN`, or unprivileged mounting via
   `fusermount3` (the `rfuse3` `unprivileged` feature is enabled in this build).
 
@@ -147,10 +149,16 @@ generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
   contents are retained. Relative runtime paths in retained configs are resolved
   against the explicit or inferred data root.
 - Retained upgrades recursively reconcile ownership for the local store and
-  Antares upper/CL data. FUSE workspace and mount roots are not traversed.
+  Antares upper/CL data. FUSE workspace and mount roots are not traversed, and
+  an upgrade is rejected until any nested mount below a migrated tree is
+  unmounted.
 - On an existing systemd installation, `--no-service` leaves the unit untouched
   and preserves ownership for its configured `User` rather than reassigning the
   config and data to the invoking sudo user.
+- Service setup verifies that systemd is reachable before creating the service
+  account or changing ownership. Use `--no-service` on hosts without systemd.
+- Installer config checks clear ambient `SCORPIO_*` daemon overrides so a
+  retained file is validated exactly as the generated systemd unit will load it.
 - `--workspace` and `--store-path` must be children of the dedicated
   `--data-root`; filesystem roots, symlink escapes, shell metacharacters, and
   nonempty directories without an existing ScorpioFS config are rejected.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -169,7 +169,10 @@ generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
   nonempty directories without an existing ScorpioFS config are rejected.
 - FUSE workspace/Antares mount roots must not equal, contain, or sit inside
   persistent store, config, upper, CL, or state paths; mount roots also may not
-  overlap each other.
+  overlap each other. Installed binaries and the main `scorpio.toml` must also
+  remain outside both mount roots.
+- Git author/email values may contain tabs, which are escaped in TOML; other
+  control characters are rejected before installation begins.
 - `--release-base-url` (or `SCORPIO_RELEASE_BASE_URL`) points the installer at
   a mirror or local HTTP server using the same `<base>/<version>/<asset>`
   layout as GitHub releases. The PR build uses this to exercise a complete

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -133,6 +133,12 @@ tarball, **verifies its SHA256 checksum**, installs `scorpio`/`antares`, creates
 the `scorpiofs` service user, prepares the FUSE group and data directories, and
 generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
 
+When a systemd service is selected, the installer waits for the configured
+`/health` endpoint before reporting success. During an upgrade, a failure after
+stopping the existing service triggers a best-effort service restart. Existing
+data-directory permissions are preserved; only newly created directories use
+the installer's default `0755` mode.
+
 - Run `sudo bash install.sh` for the interactive flow. It supports `curl | bash`
   because prompts are read from a verified controlling terminal.
 - The API defaults to `127.0.0.1:2725` because it has no authentication. A

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -182,7 +182,9 @@ generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
   existing managed unit; stop the user-run daemon and unmount it before retrying.
   Managed upgrades retain the old configured mount paths until the active unit
   is stopped, then clean any FUSE roots it leaves behind before installing the
-  new binary, config, and unit.
+  new binary, config, and unit. This also applies when `--overwrite-config`
+  migrates to an empty new data root; all-relative old configs are rejected in
+  that case because their previous mount locations cannot be inferred safely.
 - `--release-base-url` (or `SCORPIO_RELEASE_BASE_URL`) points the installer at
   a mirror or local HTTP server using the same `<base>/<version>/<asset>`
   layout as GitHub releases. The PR build uses this to exercise a complete

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -151,8 +151,8 @@ generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
 - Retained upgrades recursively reconcile ownership for the local store and
   Antares upper/CL data. FUSE workspace and mount roots are not traversed, and
   an upgrade is rejected until any nested mount below a migrated tree is
-  unmounted. When the service user changes, an active unit is stopped before
-  this migration and started under the new account afterward.
+  unmounted. A managed active unit is stopped before its binary, config, or unit
+  is replaced and then started under the configured account.
 - On an existing systemd installation, `--no-service` leaves the unit untouched
   and preserves ownership for its configured `User` rather than reassigning the
   config and data to the invoking sudo user.
@@ -175,7 +175,12 @@ generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
   control characters are rejected from every generated TOML string before
   installation begins.
 - Inaccessible stale FUSE workspace/Antares mounts are lazily detached before
-  directory preparation; accessible active mount roots are not chowned.
+  directory preparation. A non-FUSE mount at either configured root is rejected
+  and never detached. Service setup rejects an accessible mount not owned by an
+  existing managed unit; stop the user-run daemon and unmount it before retrying.
+  Managed upgrades retain the old configured mount paths until the active unit
+  is stopped, then clean any FUSE roots it leaves behind before installing the
+  new binary, config, and unit.
 - `--release-base-url` (or `SCORPIO_RELEASE_BASE_URL`) points the installer at
   a mirror or local HTTP server using the same `<base>/<version>/<asset>`
   layout as GitHub releases. The PR build uses this to exercise a complete

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -151,7 +151,8 @@ generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
 - Retained upgrades recursively reconcile ownership for the local store and
   Antares upper/CL data. FUSE workspace and mount roots are not traversed, and
   an upgrade is rejected until any nested mount below a migrated tree is
-  unmounted.
+  unmounted. When the service user changes, an active unit is stopped before
+  this migration and started under the new account afterward.
 - On an existing systemd installation, `--no-service` leaves the unit untouched
   and preserves ownership for its configured `User` rather than reassigning the
   config and data to the invoking sudo user.
@@ -159,6 +160,9 @@ generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
   account or changing ownership. Use `--no-service` on hosts without systemd.
 - Installer config checks clear ambient `SCORPIO_*` daemon overrides so a
   retained file is validated exactly as the generated systemd unit will load it.
+- A retained-config `--dry-run` resolves effective paths with the already
+  installed `scorpio` binary. It fails explicitly when that binary is missing,
+  because the preview could not otherwise validate the real upgrade paths.
 - `--workspace` and `--store-path` must be children of the dedicated
   `--data-root`; filesystem roots, symlink escapes, shell metacharacters, and
   nonempty directories without an existing ScorpioFS config are rejected.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -142,6 +142,10 @@ generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
 - System packages are installed via apt/dnf/pacman (skip with `--no-deps`).
 - `--uninstall` removes the binaries and service unit and leaves config/data in
   place.
+- `--release-base-url` (or `SCORPIO_RELEASE_BASE_URL`) points the installer at
+  a mirror or local HTTP server using the same `<base>/<version>/<asset>`
+  layout as GitHub releases. The PR build uses this to exercise a complete
+  local package/checksum/install/config-validation flow.
 
 ```bash
 bash install.sh                                      # interactive install

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -212,8 +212,13 @@ curl -fsSL https://raw.githubusercontent.com/gitmono-dev/scorpiofs/main/install.
     --lfs-url https://mega.example.com/lfs \
     --http-addr 127.0.0.1:2725
 
-# Install binaries and config without systemd or /etc/fuse.conf changes.
+# Keep /etc/fuse.conf unchanged when user_allow_other is already enabled.
 sudo bash install.sh --non-interactive --no-service --no-user-allow-other \
+  --base-url https://mega.example.com \
+  --lfs-url https://mega.example.com/lfs
+
+# On a host without user_allow_other, use this instead of the command above.
+sudo bash install.sh --non-interactive --no-service --enable-user-allow-other \
   --base-url https://mega.example.com \
   --lfs-url https://mega.example.com/lfs
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -124,17 +124,31 @@ crashes; `ExecStopPost` lazily unmounts any residual mountpoint.
 
 ## install.sh
 
-`install.sh` downloads a release tarball, **verifies its SHA256 checksum**, and
-installs `scorpio`/`antares` plus a generated `/etc/scorpiofs/scorpio.toml`.
+`install.sh` is the recommended interactive installer. It asks for the
+Mega/monorepo `base_url`, `lfs_url`, local paths, HTTP bind address, FUSE
+permission, and whether to create a systemd service. It downloads a release
+tarball, **verifies its SHA256 checksum**, installs `scorpio`/`antares`, creates
+the `scorpiofs` service user, prepares the FUSE group and data directories, and
+generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
 
+- Run `bash install.sh` for the interactive flow. It supports `curl | bash`
+  because prompts are read from `/dev/tty`.
+- The API defaults to `127.0.0.1:2725` because it has no authentication. A
+  non-loopback bind requires `--allow-public-api` and an external firewall or
+  authenticating reverse proxy.
 - Always supports `--dry-run` to preview every action.
-- It never modifies `/etc/fuse.conf` unless you pass `--enable-user-allow-other`.
+- It only modifies `/etc/fuse.conf` after the explicit interactive confirmation
+  or when `--enable-user-allow-other` is passed.
 - System packages are installed via apt/dnf/pacman (skip with `--no-deps`).
-- `--uninstall` removes the binaries and leaves config/data in place.
+- `--uninstall` removes the binaries and service unit and leaves config/data in
+  place.
 
 ```bash
-bash install.sh --version v0.3.0 --dry-run   # preview
-sudo bash install.sh --version v0.3.0        # install
+bash install.sh                                      # interactive install
+bash install.sh --version v0.4.0 --dry-run           # preview
+bash install.sh --version v0.4.0 --non-interactive \
+  --base-url https://mega.example.com \
+  --lfs-url https://mega.example.com/lfs              # automation
 ```
 
 ## Releases & supply chain

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -131,8 +131,8 @@ tarball, **verifies its SHA256 checksum**, installs `scorpio`/`antares`, creates
 the `scorpiofs` service user, prepares the FUSE group and data directories, and
 generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
 
-- Run `bash install.sh` for the interactive flow. It supports `curl | bash`
-  because prompts are read from `/dev/tty`.
+- Run `sudo bash install.sh` for the interactive flow. It supports `curl | bash`
+  because prompts are read from a verified controlling terminal.
 - The API defaults to `127.0.0.1:2725` because it has no authentication. A
   non-loopback bind requires `--allow-public-api` and an external firewall or
   authenticating reverse proxy.
@@ -142,17 +142,39 @@ generates `/etc/scorpiofs/scorpio.toml` with absolute runtime paths.
 - System packages are installed via apt/dnf/pacman (skip with `--no-deps`).
 - `--uninstall` removes the binaries and service unit and leaves config/data in
   place.
+- `--overwrite-config` (or `SCORPIO_OVERWRITE_CONFIG=1`) is required when an
+  automated upgrade should replace an existing `scorpio.toml`; otherwise its
+  contents are retained while ownership is reconciled with the service user.
+- `--workspace` and `--store-path` must be children of the dedicated
+  `--data-root`; filesystem roots and broad system directories are rejected.
 - `--release-base-url` (or `SCORPIO_RELEASE_BASE_URL`) points the installer at
   a mirror or local HTTP server using the same `<base>/<version>/<asset>`
   layout as GitHub releases. The PR build uses this to exercise a complete
   local package/checksum/install/config-validation flow.
 
 ```bash
-bash install.sh                                      # interactive install
-bash install.sh --version v0.4.0 --dry-run           # preview
-bash install.sh --version v0.4.0 --non-interactive \
+# Recommended interactive install: download, inspect, and execute.
+curl -fsSLO https://raw.githubusercontent.com/gitmono-dev/scorpiofs/main/install.sh
+less install.sh
+sudo bash install.sh
+
+# One-line interactive install.
+curl -fsSL https://raw.githubusercontent.com/gitmono-dev/scorpiofs/main/install.sh | sudo bash
+
+# Automated install or reconfiguration.
+curl -fsSL https://raw.githubusercontent.com/gitmono-dev/scorpiofs/main/install.sh | \
+  sudo bash -s -- --non-interactive --overwrite-config \
+    --base-url https://mega.example.com \
+    --lfs-url https://mega.example.com/lfs \
+    --http-addr 127.0.0.1:2725
+
+# Install binaries and config without systemd or /etc/fuse.conf changes.
+sudo bash install.sh --non-interactive --no-service --no-user-allow-other \
   --base-url https://mega.example.com \
-  --lfs-url https://mega.example.com/lfs              # automation
+  --lfs-url https://mega.example.com/lfs
+
+# Remove binaries and the unit while retaining config and data.
+sudo bash install.sh --uninstall
 ```
 
 ## Releases & supply chain

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -1,10 +1,28 @@
-# in .cargo/config
+## Run with elevated privileges
+
+Add the following runner configuration to `.cargo/config.toml` if the local
+FUSE setup requires root privileges:
+
+```toml
 [target.x86_64-unknown-linux-gnu]
 runner = 'sudo -E'
+```
 
-# in /etc/fuse.conf
-enable user_allow_other
+## Ubuntu dependencies
 
-# dependencies
-sudo apt install libfuse-dev
-sudo apt install librust-openssl-dev
+```bash
+sudo apt update
+sudo apt install build-essential pkg-config libfuse3-dev libssl-dev
+```
+
+## Optional `allow_other` support
+
+Only when mounts must be accessible to users other than the process owner,
+uncomment or add this exact line in `/etc/fuse.conf`:
+
+```text
+user_allow_other
+```
+
+This setting permits FUSE filesystems to use the `allow_other` mount option.
+Leave it disabled when that access is not required.

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -15,14 +15,15 @@ sudo apt update
 sudo apt install build-essential pkg-config libfuse3-dev libssl-dev
 ```
 
-## Optional `allow_other` support
+## Required `allow_other` support for unprivileged runs
 
-Only when mounts must be accessible to users other than the process owner,
-uncomment or add this exact line in `/etc/fuse.conf`:
+ScorpioFS requests the `allow_other` mount option for its FUSE mounts. Before
+running it as a non-root user, uncomment or add this exact line in
+`/etc/fuse.conf`:
 
 ```text
 user_allow_other
 ```
 
 This setting permits FUSE filesystems to use the `allow_other` mount option.
-Leave it disabled when that access is not required.
+The interactive installer can enable it with `--enable-user-allow-other`.

--- a/install.sh
+++ b/install.sh
@@ -782,7 +782,7 @@ configure_interactively() {
     fi
 
     validate_bind "$HTTP_ADDR"
-    if ! is_loopback_host "$BIND_HOST"; then
+    if ! is_loopback_host "$BIND_HOST" && [ "$ALLOW_PUBLIC_API" -ne 1 ]; then
         warn "${HTTP_ADDR} is not loopback. ScorpioFS has no HTTP authentication."
         prompt_yes_no PUBLIC_API_OK "Continue with an externally reachable API only behind a firewall/auth proxy" "n"
         if [ "$PUBLIC_API_OK" -eq 1 ]; then ALLOW_PUBLIC_API=1; else HTTP_ADDR="127.0.0.1:2725"; fi

--- a/install.sh
+++ b/install.sh
@@ -796,6 +796,50 @@ configure_interactively() {
     fi
 }
 
+current_user_can_search_config_dir() {
+    local directory="$CONFDIR" parent
+    while [ ! -e "$directory" ] && [ "$directory" != / ]; do
+        parent="${directory%/*}"
+        [ -n "$parent" ] || parent=/
+        [ "$parent" != "$directory" ] || break
+        directory="$parent"
+    done
+    [ -d "$directory" ] && [ -x "$directory" ]
+}
+
+detect_existing_config() {
+    local config_path="${CONFDIR}/scorpio.toml"
+    local -a privileged_test
+    if [ -L "$config_path" ]; then
+        die "config file must not be a symbolic link: $config_path"
+    elif [ -f "$config_path" ]; then
+        EXISTING_CONFIG=1
+    elif [ -e "$config_path" ]; then
+        die "config path exists but is not a regular file: $config_path"
+    elif current_user_can_search_config_dir; then
+        return 0
+    else
+        if [ "$(id -u)" -eq 0 ]; then
+            return 0
+        fi
+        command -v sudo >/dev/null 2>&1 || \
+            die "cannot inspect protected config path without sudo: $config_path"
+        sudo -v || die "could not obtain permission to inspect protected config path: $config_path"
+        SUDO_BIN="sudo"
+        privileged_test=(sudo test)
+        if "${privileged_test[@]}" -L "$config_path"; then
+            die "config file must not be a symbolic link: $config_path"
+        elif "${privileged_test[@]}" -f "$config_path"; then
+            EXISTING_CONFIG=1
+        elif "${privileged_test[@]}" -e "$config_path"; then
+            die "config path exists but is not a regular file: $config_path"
+        else
+            return 0
+        fi
+    fi
+    if [ "$OVERWRITE_CONFIG" -ne 1 ]; then RETAIN_CONFIG=1; fi
+}
+
 validate_inputs() {
     BASE_URL="$(normalize_url "$BASE_URL")"
     LFS_URL="$(normalize_url "$LFS_URL")"
@@ -819,10 +863,7 @@ validate_inputs() {
     validate_path data-root "$DATA_ROOT"
     validate_path workspace "$WORKSPACE"
     validate_path store-path "$STORE_PATH"
-    if [ -f "${CONFDIR}/scorpio.toml" ]; then
-        EXISTING_CONFIG=1
-        if [ "$OVERWRITE_CONFIG" -ne 1 ]; then RETAIN_CONFIG=1; fi
-    fi
+    detect_existing_config
     validate_service_manager
     detect_existing_service_user
     validate_data_paths
@@ -1025,6 +1066,7 @@ recover_stale_runtime_mounts() {
             run_root umount -l "$mount_root" || \
                 die "could not detach stale $mount_field at $mount_root; install fuse3 or unmount it manually"
         fi
+        [ "$DRY_RUN" -eq 1 ] && continue
         path_is_mount_target "$mount_root" && \
             die "stale $mount_field is still mounted at $mount_root; unmount it and retry"
     done
@@ -1086,7 +1128,7 @@ validate_toml_text() {
 
 write_config() {
     local config_tmp="${WORKDIR:-${TMPDIR:-/tmp}}/scorpio.toml"
-    if [ -f "${CONFDIR}/scorpio.toml" ] && [ "$OVERWRITE_CONFIG" -ne 1 ]; then
+    if [ "$RETAIN_CONFIG" -eq 1 ]; then
         warn "${CONFDIR}/scorpio.toml already exists; leaving its contents unchanged"
         run_root chown "$TARGET_USER:$TARGET_GROUP" "${CONFDIR}/scorpio.toml"
         run_root chmod 0640 "${CONFDIR}/scorpio.toml"

--- a/install.sh
+++ b/install.sh
@@ -185,6 +185,7 @@ prompt_yes_no() {
 
 validate_url() {
     local field="$1" value="$2"
+    validate_toml_text "$field" "$value"
     case "$value" in
         http://*|https://*) ;;
         *) die "$field must start with http:// or https:// (got: $value)" ;;
@@ -739,6 +740,8 @@ pkg_install() {
 
 check_runtime_tools() {
     command -v findmnt >/dev/null 2>&1 || die "findmnt is required (install util-linux)"
+    command -v runuser >/dev/null 2>&1 || die "runuser is required (install util-linux)"
+    command -v timeout >/dev/null 2>&1 || die "timeout is required (install coreutils)"
 }
 
 check_fuse() {
@@ -909,6 +912,7 @@ ensure_service_account() {
 }
 
 prepare_directories() {
+    local -a directories
     if [ "$SETUP_SERVICE" -eq 1 ]; then
         TARGET_USER="$SERVICE_USER"
         if [ "$DRY_RUN" -eq 0 ]; then
@@ -927,11 +931,57 @@ prepare_directories() {
             TARGET_GROUP="$(id -gn "$TARGET_USER" 2>/dev/null || id -gn)"
         fi
     fi
-    run_root install -d -o "$TARGET_USER" -g "$TARGET_GROUP" \
-        "$DATA_ROOT" "$WORKSPACE" "$STORE_PATH" \
-        "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT" "$ANTARES_MOUNT_ROOT" \
+    directories=(
+        "$DATA_ROOT" "$STORE_PATH" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT"
         "$(dirname -- "$CONFIG_FILE")" "$(dirname -- "$ANTARES_STATE_FILE")"
+    )
+    if ! path_is_mount_target "$WORKSPACE"; then directories+=("$WORKSPACE"); fi
+    if ! path_is_mount_target "$ANTARES_MOUNT_ROOT"; then directories+=("$ANTARES_MOUNT_ROOT"); fi
+    run_root install -d -o "$TARGET_USER" -g "$TARGET_GROUP" "${directories[@]}"
     run_root install -d "$CONFDIR"
+}
+
+path_is_mount_target() {
+    local path="$1" mount_target mount_targets
+    mount_targets="$(findmnt --noheadings --raw --output TARGET)" || \
+        die "could not inspect FUSE mount roots"
+    while IFS= read -r mount_target; do
+        [ "$mount_target" = "$path" ] && return 0
+    done <<<"$mount_targets"
+    return 1
+}
+
+recover_stale_runtime_mounts() {
+    local mount_field mount_root i
+    local -a mount_fields=(workspace antares-mount-root)
+    local -a mount_roots=("$WORKSPACE" "$ANTARES_MOUNT_ROOT")
+    local -a probe
+    for ((i = 0; i < ${#mount_fields[@]}; i++)); do
+        mount_field="${mount_fields[$i]}"
+        mount_root="${mount_roots[$i]}"
+        path_is_mount_target "$mount_root" || continue
+        # $1 is intentionally expanded by the probe shell.
+        # shellcheck disable=SC2016
+        probe=(timeout 15 bash -c 'stat -L -- "$1" >/dev/null 2>&1' bash "$mount_root")
+        if [ -n "$EXISTING_SERVICE_USER" ]; then
+            probe=(runuser -u "$EXISTING_SERVICE_USER" -- "${probe[@]}")
+        fi
+        if run_root "${probe[@]}"; then
+            note "$mount_field is actively mounted; leaving the mount root unchanged during directory preparation"
+            continue
+        fi
+        warn "detaching inaccessible FUSE mount at $mount_root before installation"
+        if command -v fusermount3 >/dev/null 2>&1; then
+            run_root fusermount3 -u -z "$mount_root" || \
+                run_root umount -l "$mount_root" || \
+                die "could not detach stale $mount_field at $mount_root; unmount it and retry"
+        else
+            run_root umount -l "$mount_root" || \
+                die "could not detach stale $mount_field at $mount_root; install fuse3 or unmount it manually"
+        fi
+        path_is_mount_target "$mount_root" && \
+            die "stale $mount_field is still mounted at $mount_root; unmount it and retry"
+    done
 }
 
 validate_runtime_migration_mounts() {
@@ -1151,6 +1201,7 @@ main() {
     validate_runtime_migration_mounts
     ensure_service_account
     stop_active_service_for_user_migration
+    recover_stale_runtime_mounts
     prepare_directories
     reconcile_runtime_directories
     reconcile_runtime_files

--- a/install.sh
+++ b/install.sh
@@ -71,6 +71,7 @@ PREVIOUS_ANTARES_UPPER_ROOT=""
 PREVIOUS_ANTARES_CL_ROOT=""
 PREVIOUS_CONFIG_FILE=""
 PREVIOUS_ANTARES_STATE_FILE=""
+PREVIOUS_RUNTIME_PARENT_DIRS=()
 EXTRACTED_RELEASE=""
 REQUESTED_WORKSPACE=""
 REQUESTED_STORE_PATH=""
@@ -180,6 +181,20 @@ run_readonly() {
     else
         "$@"
     fi
+}
+
+run_as_existing_service_user() {
+    [ -n "$EXISTING_SERVICE_USER" ] || { "$@"; return; }
+    [ "$EXISTING_SERVICE_USER" = "$(id -un)" ] && { "$@"; return; }
+    if [ "$(id -u)" -eq 0 ]; then
+        runuser -u "$EXISTING_SERVICE_USER" -- "$@"
+        return
+    fi
+    command -v sudo >/dev/null 2>&1 || \
+        die "sudo is required to resolve retained runtime paths as $EXISTING_SERVICE_USER"
+    sudo -n -v || \
+        die "could not obtain non-interactive sudo privileges to resolve retained runtime paths as $EXISTING_SERVICE_USER"
+    sudo -n -u "$EXISTING_SERVICE_USER" -- "$@"
 }
 
 require_privileges() {
@@ -553,6 +568,7 @@ set_generated_runtime_paths() {
 
 run_scorpio_config_without_overrides() {
     local binary="$1" variable config_path="${CONFDIR}/scorpio.toml"
+    local effective_binary="$binary" temporary_binary="" temporary_config="" status=0
     shift
     local -a command=(env)
     while IFS= read -r variable; do
@@ -560,24 +576,50 @@ run_scorpio_config_without_overrides() {
             SCORPIO_*) command+=(-u "$variable") ;;
         esac
     done < <(compgen -e)
-    if [ "$DRY_RUN" -eq 1 ]; then
-        if [ "$(id -u)" -eq 0 ] || [ -r "${CONFDIR}/scorpio.toml" ]; then
-            "${command[@]}" "$binary" --config-path "${CONFDIR}/scorpio.toml" config "$@"
-        else
-            command -v sudo >/dev/null 2>&1 || \
-                die "sudo is required to read protected retained config during dry-run"
-            sudo -v || die "could not obtain read access for retained config during dry-run"
-            config_path="${WORKDIR}/retained-config.toml"
-            (umask 077; : >"$config_path") || \
-                die "could not create a protected config copy for retained dry-run"
-            if ! sudo cat -- "${CONFDIR}/scorpio.toml" | tee "$config_path" >/dev/null; then
-                die "could not read protected retained config during dry-run: ${CONFDIR}/scorpio.toml"
-            fi
-            "${command[@]}" "$binary" --config-path "$config_path" config "$@"
-        fi
-    else
-        run_root "${command[@]}" "$binary" --config-path "${CONFDIR}/scorpio.toml" config "$@"
+
+    if [ -n "$EXISTING_SERVICE_USER" ]; then
+        temporary_binary="$(mktemp /tmp/scorpiofs-installer-scorpio.XXXXXX)" || \
+            die "could not create a temporary ScorpioFS binary for retained path resolution"
+        cp -- "$binary" "$temporary_binary" || {
+            rm -f -- "$temporary_binary"
+            die "could not stage ScorpioFS binary for retained path resolution"
+        }
+        chmod 0755 "$temporary_binary" || {
+            rm -f -- "$temporary_binary"
+            die "could not make the temporary ScorpioFS binary executable"
+        }
+        effective_binary="$temporary_binary"
     fi
+
+    if ! run_as_existing_service_user test -r "${CONFDIR}/scorpio.toml"; then
+        local -a read_config=(cat)
+        if [ "$(id -u)" -ne 0 ]; then
+            command -v sudo >/dev/null 2>&1 || \
+                die "sudo is required to read protected retained config"
+            [ "$DRY_RUN" -eq 0 ] || \
+                sudo -v || die "could not obtain read access for retained config during dry-run"
+            read_config=(sudo cat)
+        fi
+        temporary_config="$(run_as_existing_service_user mktemp /tmp/scorpiofs-installer-config.XXXXXX)" || \
+            die "could not create a protected retained config copy"
+        config_path="$temporary_config"
+        if ! "${read_config[@]}" -- "${CONFDIR}/scorpio.toml" | \
+            run_as_existing_service_user tee "$config_path" >/dev/null; then
+            rm -f -- "$temporary_config"
+            [ -n "$temporary_binary" ] && rm -f -- "$temporary_binary"
+            die "could not read protected retained config: ${CONFDIR}/scorpio.toml"
+        fi
+    fi
+
+    if run_as_existing_service_user "${command[@]}" "$effective_binary" \
+        --config-path "$config_path" config "$@"; then
+        status=0
+    else
+        status=$?
+    fi
+    [ -n "$temporary_config" ] && rm -f -- "$temporary_config"
+    [ -n "$temporary_binary" ] && rm -f -- "$temporary_binary"
+    return "$status"
 }
 
 load_configured_runtime_paths() {
@@ -634,6 +676,15 @@ prepare_effective_runtime_paths() {
         PREVIOUS_ANTARES_CL_ROOT="$ANTARES_CL_ROOT"
         PREVIOUS_CONFIG_FILE="$CONFIG_FILE"
         PREVIOUS_ANTARES_STATE_FILE="$ANTARES_STATE_FILE"
+        PREVIOUS_RUNTIME_PARENT_DIRS=()
+        local previous_path previous_parent
+        for previous_path in "$PREVIOUS_CONFIG_FILE" "$PREVIOUS_ANTARES_STATE_FILE"; do
+            previous_parent="$(dirname -- "$previous_path")"
+            while [[ "$previous_parent" == "$PREVIOUS_DATA_ROOT"/* ]]; do
+                PREVIOUS_RUNTIME_PARENT_DIRS+=("$previous_parent")
+                previous_parent="$(dirname -- "$previous_parent")"
+            done
+        done
     fi
 
     if [ "$RETAIN_CONFIG" -eq 1 ]; then
@@ -1127,6 +1178,12 @@ restore_runtime_ownership() {
             restore_failed=1
         fi
     done
+    for runtime_dir in "${PREVIOUS_RUNTIME_PARENT_DIRS[@]}"; do
+        if run_root test -d "$runtime_dir" && ! run_root chown \
+            "$EXISTING_SERVICE_USER:$previous_group" -- "$runtime_dir"; then
+            restore_failed=1
+        fi
+    done
     [ "$restore_failed" -eq 0 ]
 }
 
@@ -1321,11 +1378,21 @@ recover_stale_runtime_mounts() {
 }
 
 validate_runtime_migration_mounts() {
-    local runtime_dir mount_target mount_targets
-    mount_targets="$(findmnt --noheadings --raw --output TARGET)" || \
+    local runtime_dir mount_target mount_targets path parent
+    local -a runtime_dirs=(
+        "$STORE_PATH" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT"
+    )
+    for path in "$CONFIG_FILE" "$ANTARES_STATE_FILE"; do
+        parent="$(dirname -- "$path")"
+        while [[ "$parent" == "$DATA_ROOT"/* ]]; do
+            runtime_dirs+=("$parent")
+            parent="$(dirname -- "$parent")"
+        done
+    done
+    mount_targets="$(run_readonly findmnt --noheadings --raw --output TARGET)" || \
         die "could not inspect mounts before migrating runtime ownership"
-    for runtime_dir in "$STORE_PATH" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT"; do
-        if [ -d "$runtime_dir" ]; then
+    for runtime_dir in "${runtime_dirs[@]}"; do
+        if run_readonly test -d "$runtime_dir"; then
             while IFS= read -r mount_target; do
                 case "$mount_target" in
                     "$runtime_dir")
@@ -1425,9 +1492,15 @@ EOF
 
 validate_installed_config() {
     [ "$DRY_RUN" -eq 0 ] || return 0
+    local previous_service_user="$EXISTING_SERVICE_USER"
+    if [ "$SETUP_SERVICE" -eq 1 ]; then
+        EXISTING_SERVICE_USER="$SERVICE_USER"
+    fi
     if ! run_scorpio_config_without_overrides "${PREFIX}/bin/scorpio" validate; then
+        EXISTING_SERVICE_USER="$previous_service_user"
         die "generated or retained config is invalid: ${CONFDIR}/scorpio.toml"
     fi
+    EXISTING_SERVICE_USER="$previous_service_user"
 }
 
 validate_user_allow_other() {

--- a/install.sh
+++ b/install.sh
@@ -254,14 +254,21 @@ validate_path() {
     [[ "$value" == /* ]] || die "$field must be an absolute path: $value"
     [[ "$value" != *[[:space:]]* ]] || die "$field must not contain whitespace"
     [[ "$value" != *$'\n'* && "$value" != *$'\r'* ]] || die "$field must not contain a newline"
-    [[ "$value" != *'"'* && "$value" != *"'"* && "$value" != *'`'* && \
-        "$value" != *'$'* && "$value" != *\\* && "$value" != *'%'* ]] || \
+    [[ "$value" =~ ^/[A-Za-z0-9._+:/-]*$ ]] || \
         die "$field contains a character unsafe for shell or systemd use"
     [[ "$value" != *'//'* ]] || die "$field must not contain repeated slashes"
     case "/${value#/}/" in
         *'/../'*|*'/./'*) die "$field must not contain . or .. path components" ;;
     esac
     [ ! -L "$value" ] || die "$field must not be a symbolic link: $value"
+}
+
+canonicalize_paths() {
+    PREFIX="$(realpath -m -- "$PREFIX")"
+    CONFDIR="$(realpath -m -- "$CONFDIR")"
+    DATA_ROOT="$(realpath -m -- "$DATA_ROOT")"
+    WORKSPACE="$(realpath -m -- "$WORKSPACE")"
+    STORE_PATH="$(realpath -m -- "$STORE_PATH")"
 }
 
 validate_data_paths() {
@@ -278,6 +285,15 @@ validate_data_paths() {
         "$DATA_ROOT"/*) ;;
         *) die "store-path must be inside data-root ($DATA_ROOT): $STORE_PATH" ;;
     esac
+    local runtime_file
+    for runtime_file in "$DATA_ROOT/config.toml" "$DATA_ROOT/antares/state.toml"; do
+        [ ! -L "$runtime_file" ] || die "runtime state file must not be a symbolic link: $runtime_file"
+    done
+    [ ! -L "$CONFDIR/scorpio.toml" ] || die "config file must not be a symbolic link: $CONFDIR/scorpio.toml"
+    if [ -d "$DATA_ROOT" ] && [ ! -f "$CONFDIR/scorpio.toml" ] && \
+        [ -n "$(find "$DATA_ROOT" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+        die "refusing to change ownership of a nonempty data-root without an existing ScorpioFS config: $DATA_ROOT"
+    fi
 }
 
 validate_bind() {
@@ -383,6 +399,8 @@ check_tools() {
         die "curl or wget is required"
     fi
     command -v tar >/dev/null 2>&1 || die "tar is required"
+    command -v realpath >/dev/null 2>&1 || die "realpath is required"
+    command -v find >/dev/null 2>&1 || die "find is required"
 }
 
 fetch() {
@@ -480,6 +498,12 @@ validate_inputs() {
     validate_url base_url "$BASE_URL"
     validate_url lfs_url "$LFS_URL"
     validate_url release-base-url "$RELEASE_BASE_URL"
+    validate_path prefix "$PREFIX"
+    validate_path config-dir "$CONFDIR"
+    validate_path data-root "$DATA_ROOT"
+    validate_path workspace "$WORKSPACE"
+    validate_path store-path "$STORE_PATH"
+    canonicalize_paths
     validate_path prefix "$PREFIX"
     validate_path config-dir "$CONFDIR"
     validate_path data-root "$DATA_ROOT"
@@ -583,6 +607,15 @@ prepare_directories() {
         "$DATA_ROOT/antares" "$DATA_ROOT/antares/upper" \
         "$DATA_ROOT/antares/cl" "$DATA_ROOT/antares/mnt"
     run_root install -d "$CONFDIR"
+}
+
+reconcile_runtime_files() {
+    local runtime_file
+    for runtime_file in "$DATA_ROOT/config.toml" "$DATA_ROOT/antares/state.toml"; do
+        if [ -e "$runtime_file" ]; then
+            run_root chown "$TARGET_USER:$TARGET_GROUP" "$runtime_file"
+        fi
+    done
 }
 
 toml_escape() {
@@ -749,6 +782,7 @@ main() {
     install_binaries
     ensure_service_account
     prepare_directories
+    reconcile_runtime_files
     write_config
     validate_installed_config
     enable_user_allow_other

--- a/install.sh
+++ b/install.sh
@@ -65,6 +65,11 @@ HAD_OLD_CONFIG=0
 HAD_OLD_UNIT=0
 PREVIOUS_WORKSPACE=""
 PREVIOUS_ANTARES_MOUNT_ROOT=""
+PREVIOUS_STORE_PATH=""
+PREVIOUS_ANTARES_UPPER_ROOT=""
+PREVIOUS_ANTARES_CL_ROOT=""
+PREVIOUS_CONFIG_FILE=""
+PREVIOUS_ANTARES_STATE_FILE=""
 EXTRACTED_RELEASE=""
 REQUESTED_WORKSPACE=""
 REQUESTED_STORE_PATH=""
@@ -88,6 +93,9 @@ cleanup() {
             if ! restore_upgrade_artifacts; then
                 warn "could not restore all previous ScorpioFS artifacts"
             fi
+        fi
+        if ! restore_runtime_ownership; then
+            warn "could not restore runtime ownership for the previous service user"
         fi
         warn "installation failed after stopping scorpiofs.service; attempting to restore the managed service"
         if ! run_root systemctl start scorpiofs.service; then
@@ -594,6 +602,11 @@ prepare_effective_runtime_paths() {
         validate_runtime_paths
         PREVIOUS_WORKSPACE="$WORKSPACE"
         PREVIOUS_ANTARES_MOUNT_ROOT="$ANTARES_MOUNT_ROOT"
+        PREVIOUS_STORE_PATH="$STORE_PATH"
+        PREVIOUS_ANTARES_UPPER_ROOT="$ANTARES_UPPER_ROOT"
+        PREVIOUS_ANTARES_CL_ROOT="$ANTARES_CL_ROOT"
+        PREVIOUS_CONFIG_FILE="$CONFIG_FILE"
+        PREVIOUS_ANTARES_STATE_FILE="$ANTARES_STATE_FILE"
     fi
 
     if [ "$RETAIN_CONFIG" -eq 1 ]; then
@@ -1059,6 +1072,30 @@ restore_upgrade_artifacts() {
     if [ "$HAD_OLD_UNIT" -eq 1 ]; then
         run_root systemctl daemon-reload || restore_failed=1
     fi
+    [ "$restore_failed" -eq 0 ]
+}
+
+restore_runtime_ownership() {
+    [ -n "$EXISTING_SERVICE_USER" ] || return 0
+    [ "$EXISTING_SERVICE_USER" = "$SERVICE_USER" ] && return 0
+
+    local previous_group runtime_dir runtime_file restore_failed=0
+    previous_group="$(id -gn "$EXISTING_SERVICE_USER")" || return 1
+    for runtime_dir in "$PREVIOUS_STORE_PATH" "$PREVIOUS_ANTARES_UPPER_ROOT" \
+        "$PREVIOUS_ANTARES_CL_ROOT"; do
+        [ -n "$runtime_dir" ] || continue
+        if run_root test -d "$runtime_dir" && ! run_root chown -R -h -P \
+            "$EXISTING_SERVICE_USER:$previous_group" -- "$runtime_dir"; then
+            restore_failed=1
+        fi
+    done
+    for runtime_file in "$PREVIOUS_CONFIG_FILE" "$PREVIOUS_ANTARES_STATE_FILE"; do
+        [ -n "$runtime_file" ] || continue
+        if run_root test -e "$runtime_file" && ! run_root chown \
+            "$EXISTING_SERVICE_USER:$previous_group" -- "$runtime_file"; then
+            restore_failed=1
+        fi
+    done
     [ "$restore_failed" -eq 0 ]
 }
 

--- a/install.sh
+++ b/install.sh
@@ -420,18 +420,22 @@ set_generated_runtime_paths() {
     ANTARES_STATE_FILE="$DATA_ROOT/antares/state.toml"
 }
 
+run_scorpio_config_without_overrides() {
+    local binary="$1" variable
+    shift
+    local -a command=(env)
+    while IFS= read -r variable; do
+        case "$variable" in
+            SCORPIO_*) command+=(-u "$variable") ;;
+        esac
+    done < <(compgen -e)
+    run_root "${command[@]}" "$binary" --config-path "${CONFDIR}/scorpio.toml" config "$@"
+}
+
 load_configured_runtime_paths() {
     local binary="$1" output_file="${WORKDIR}/installer-paths"
     local -a paths=()
-    if ! run_root env \
-        -u SCORPIO_WORKSPACE \
-        -u SCORPIO_STORE_PATH \
-        -u SCORPIO_CONFIG_FILE \
-        -u SCORPIO_ANTARES_UPPER_ROOT \
-        -u SCORPIO_ANTARES_CL_ROOT \
-        -u SCORPIO_ANTARES_MOUNT_ROOT \
-        -u SCORPIO_ANTARES_STATE_FILE \
-        "$binary" --config-path "${CONFDIR}/scorpio.toml" config installer-paths >"$output_file"; then
+    if ! run_scorpio_config_without_overrides "$binary" installer-paths >"$output_file"; then
         die "could not safely resolve runtime paths from retained config: ${CONFDIR}/scorpio.toml"
     fi
     mapfile -d '' -t paths <"$output_file"
@@ -493,6 +497,15 @@ detect_existing_service_user() {
     getent passwd "$candidate" >/dev/null 2>&1 || \
         die "existing scorpiofs.service user does not exist: $candidate"
     EXISTING_SERVICE_USER="$candidate"
+}
+
+validate_service_manager() {
+    [ "$SETUP_SERVICE" -eq 1 ] || return 0
+    command -v systemctl >/dev/null 2>&1 || \
+        die "systemctl is required for service setup; pass --no-service for a user-run installation"
+    if [ "$DRY_RUN" -eq 0 ] && ! systemctl show-environment >/dev/null 2>&1; then
+        die "systemd is not running or cannot be reached; pass --no-service for a user-run installation"
+    fi
 }
 
 validate_bind() {
@@ -635,14 +648,18 @@ pkg_install() {
     [ "$INSTALL_DEPS" -eq 1 ] || { note "skipping dependency installation (--no-deps)"; return 0; }
     if command -v apt-get >/dev/null 2>&1; then
         run_root apt-get update
-        run_root apt-get install -y --no-install-recommends fuse3 openssl ca-certificates
+        run_root apt-get install -y --no-install-recommends fuse3 openssl ca-certificates util-linux
     elif command -v dnf >/dev/null 2>&1; then
-        run_root dnf install -y fuse3 openssl ca-certificates
+        run_root dnf install -y fuse3 openssl ca-certificates util-linux
     elif command -v pacman >/dev/null 2>&1; then
-        run_root pacman -Sy --noconfirm fuse3 openssl ca-certificates
+        run_root pacman -Sy --noconfirm fuse3 openssl ca-certificates util-linux
     else
-        warn "no supported package manager found; install fuse3, openssl, and ca-certificates manually"
+        warn "no supported package manager found; install fuse3, openssl, ca-certificates, and util-linux manually"
     fi
+}
+
+check_runtime_tools() {
+    command -v findmnt >/dev/null 2>&1 || die "findmnt is required (install util-linux)"
 }
 
 check_fuse() {
@@ -720,6 +737,7 @@ validate_inputs() {
         EXISTING_CONFIG=1
         if [ "$OVERWRITE_CONFIG" -ne 1 ]; then RETAIN_CONFIG=1; fi
     fi
+    validate_service_manager
     detect_existing_service_user
     validate_data_paths
     validate_bind "$HTTP_ADDR"
@@ -830,11 +848,20 @@ prepare_directories() {
 }
 
 reconcile_runtime_directories() {
-    local runtime_dir
+    local runtime_dir mount_target mount_targets
     # These are persistent local data trees. Workspace and mount roots are
     # intentionally excluded because they may currently be FUSE mountpoints.
     for runtime_dir in "$STORE_PATH" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT"; do
         if [ -d "$runtime_dir" ]; then
+            mount_targets="$(findmnt --list --noheadings --raw --output TARGET)" || \
+                die "could not inspect mounts before migrating ownership under $runtime_dir"
+            while IFS= read -r mount_target; do
+                case "$mount_target" in
+                    "$runtime_dir"/*)
+                        die "refusing ownership migration across nested mount $mount_target under $runtime_dir; unmount it and retry"
+                        ;;
+                esac
+            done <<<"$mount_targets"
             run_root chown -R -h -P "$TARGET_USER:$TARGET_GROUP" -- "$runtime_dir"
         fi
     done
@@ -905,7 +932,7 @@ EOF
 
 validate_installed_config() {
     [ "$DRY_RUN" -eq 0 ] || return 0
-    if ! run_root "${PREFIX}/bin/scorpio" --config-path "${CONFDIR}/scorpio.toml" config validate; then
+    if ! run_scorpio_config_without_overrides "${PREFIX}/bin/scorpio" validate; then
         die "generated or retained config is invalid: ${CONFDIR}/scorpio.toml"
     fi
 }
@@ -926,10 +953,6 @@ enable_user_allow_other() {
 
 install_systemd_service() {
     [ "$SETUP_SERVICE" -eq 1 ] || return 0
-    if ! command -v systemctl >/dev/null 2>&1; then
-        warn "systemctl is unavailable; binaries and config were installed without a service"
-        return 0
-    fi
     if [ "$DRY_RUN" -eq 1 ]; then
         note "would install /etc/systemd/system/scorpiofs.service and enable it"
         return 0
@@ -1016,6 +1039,7 @@ main() {
 
     note "installing ScorpioFS ${VERSION} for $(detect_target)"
     pkg_install
+    check_runtime_tools
     check_fuse
     install_binaries
     ensure_service_account

--- a/install.sh
+++ b/install.sh
@@ -1163,14 +1163,21 @@ restore_runtime_ownership() {
         ! run_root chown "$EXISTING_SERVICE_USER:$previous_group" -- "$PREVIOUS_DATA_ROOT"; then
         restore_failed=1
     fi
-    for runtime_dir in "$PREVIOUS_STORE_PATH" "$PREVIOUS_ANTARES_UPPER_ROOT" \
-        "$PREVIOUS_ANTARES_CL_ROOT"; do
-        [ -n "$runtime_dir" ] || continue
-        if run_root test -d "$runtime_dir" && ! run_root chown -R -h -P \
-            "$EXISTING_SERVICE_USER:$previous_group" -- "$runtime_dir"; then
-            restore_failed=1
-        fi
-    done
+    local -a previous_runtime_dirs=(
+        "$PREVIOUS_STORE_PATH" "$PREVIOUS_ANTARES_UPPER_ROOT" "$PREVIOUS_ANTARES_CL_ROOT"
+    )
+    if ! validate_mount_targets "${previous_runtime_dirs[@]}"; then
+        warn "${MOUNT_VALIDATION_ERROR}; skipping recursive ownership restore"
+        restore_failed=1
+    else
+        for runtime_dir in "${previous_runtime_dirs[@]}"; do
+            [ -n "$runtime_dir" ] || continue
+            if run_root test -d "$runtime_dir" && ! run_root chown -R -h -P \
+                "$EXISTING_SERVICE_USER:$previous_group" -- "$runtime_dir"; then
+                restore_failed=1
+            fi
+        done
+    fi
     for runtime_file in "$PREVIOUS_CONFIG_FILE" "$PREVIOUS_ANTARES_STATE_FILE"; do
         [ -n "$runtime_file" ] || continue
         if run_root test -e "$runtime_file" && ! run_root chown \
@@ -1377,8 +1384,35 @@ recover_stale_runtime_mounts() {
     return 0
 }
 
+validate_mount_targets() {
+    local runtime_dir mount_target mount_targets
+    MOUNT_VALIDATION_ERROR=""
+    mount_targets="$(run_readonly findmnt --noheadings --raw --output TARGET)" || {
+        MOUNT_VALIDATION_ERROR="could not inspect mounts before migrating runtime ownership"
+        return 1
+    }
+    for runtime_dir in "$@"; do
+        [ -n "$runtime_dir" ] || continue
+        if run_readonly test -d "$runtime_dir"; then
+            while IFS= read -r mount_target; do
+                case "$mount_target" in
+                    "$runtime_dir")
+                        MOUNT_VALIDATION_ERROR="refusing ownership migration across mount $mount_target at runtime directory; unmount it and retry"
+                        return 1
+                        ;;
+                    "$runtime_dir"/*)
+                        MOUNT_VALIDATION_ERROR="refusing ownership migration across nested mount $mount_target under $runtime_dir; unmount it and retry"
+                        return 1
+                        ;;
+                esac
+            done <<<"$mount_targets"
+        fi
+    done
+    return 0
+}
+
 validate_runtime_migration_mounts() {
-    local runtime_dir mount_target mount_targets path parent
+    local path parent
     local -a runtime_dirs=(
         "$STORE_PATH" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT"
     )
@@ -1389,22 +1423,7 @@ validate_runtime_migration_mounts() {
             parent="$(dirname -- "$parent")"
         done
     done
-    mount_targets="$(run_readonly findmnt --noheadings --raw --output TARGET)" || \
-        die "could not inspect mounts before migrating runtime ownership"
-    for runtime_dir in "${runtime_dirs[@]}"; do
-        if run_readonly test -d "$runtime_dir"; then
-            while IFS= read -r mount_target; do
-                case "$mount_target" in
-                    "$runtime_dir")
-                        die "refusing ownership migration across mount $mount_target at runtime directory; unmount it and retry"
-                        ;;
-                    "$runtime_dir"/*)
-                        die "refusing ownership migration across nested mount $mount_target under $runtime_dir; unmount it and retry"
-                        ;;
-                esac
-            done <<<"$mount_targets"
-        fi
-    done
+    validate_mount_targets "${runtime_dirs[@]}" || die "$MOUNT_VALIDATION_ERROR"
 }
 
 reconcile_runtime_directories() {
@@ -1627,7 +1646,18 @@ wait_for_service_health() {
 uninstall() {
     require_privileges
     if command -v systemctl >/dev/null 2>&1; then
-        run_root systemctl disable --now scorpiofs.service 2>/dev/null || true
+        if run_readonly test -e /etc/systemd/system/scorpiofs.service || \
+            run_root systemctl is-active --quiet scorpiofs.service; then
+            if ! run_root systemctl disable --now scorpiofs.service 2>/dev/null; then
+                if run_root systemctl is-active --quiet scorpiofs.service; then
+                    die "could not stop scorpiofs.service; refusing to remove its unit or binaries"
+                fi
+                warn "systemd did not report a successful stop; service is inactive, continuing uninstall"
+            fi
+            if run_root systemctl is-active --quiet scorpiofs.service; then
+                die "scorpiofs.service is still active; refusing to remove its unit or binaries"
+            fi
+        fi
         run_root rm -f /etc/systemd/system/scorpiofs.service
         run_root systemctl daemon-reload 2>/dev/null || true
     fi

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,8 @@ INTERACTIVE=1
 ASSUME_YES=0
 ALLOW_PUBLIC_API=0
 OVERWRITE_CONFIG=0
+SERVICE_CHOICE_SET=0
+FUSE_CHOICE_SET=0
 WORKDIR=""
 SUDO_BIN=""
 TARGET_USER=""
@@ -205,14 +207,14 @@ parse_args() {
             --store-path) [ "$#" -ge 2 ] || die "--store-path needs a value"; STORE_PATH="$2"; shift 2 ;;
             --http-addr) [ "$#" -ge 2 ] || die "--http-addr needs a value"; HTTP_ADDR="$2"; shift 2 ;;
             --allow-public-api) ALLOW_PUBLIC_API=1; shift ;;
-            --no-service) SETUP_SERVICE=0; shift ;;
+            --no-service) SETUP_SERVICE=0; SERVICE_CHOICE_SET=1; shift ;;
             --non-interactive) INTERACTIVE=0; shift ;;
             --yes) ASSUME_YES=1; shift ;;
             --dry-run) DRY_RUN=1; shift ;;
             --uninstall) DO_UNINSTALL=1; INTERACTIVE=0; shift ;;
             --no-deps) INSTALL_DEPS=0; shift ;;
-            --enable-user-allow-other) ENABLE_USER_ALLOW_OTHER=1; shift ;;
-            --no-user-allow-other) ENABLE_USER_ALLOW_OTHER=0; shift ;;
+            --enable-user-allow-other) ENABLE_USER_ALLOW_OTHER=1; FUSE_CHOICE_SET=1; shift ;;
+            --no-user-allow-other) ENABLE_USER_ALLOW_OTHER=0; FUSE_CHOICE_SET=1; shift ;;
             -h|--help) usage; exit 0 ;;
             *) die "unknown option: $1 (see --help)" ;;
         esac
@@ -301,8 +303,12 @@ configure_interactively() {
     prompt_value HTTP_ADDR "HTTP listen address" "$HTTP_ADDR"
     prompt_value GIT_AUTHOR "Default Git author" "$GIT_AUTHOR"
     prompt_value GIT_EMAIL "Default Git email" "$GIT_EMAIL"
-    prompt_yes_no ENABLE_USER_ALLOW_OTHER "Enable user_allow_other in /etc/fuse.conf" "y"
-    prompt_yes_no SETUP_SERVICE "Install and start systemd service" "y"
+    if [ "$FUSE_CHOICE_SET" -eq 0 ]; then
+        prompt_yes_no ENABLE_USER_ALLOW_OTHER "Enable user_allow_other in /etc/fuse.conf" "y"
+    fi
+    if [ "$SERVICE_CHOICE_SET" -eq 0 ]; then
+        prompt_yes_no SETUP_SERVICE "Install and start systemd service" "y"
+    fi
     if [ "$SETUP_SERVICE" -eq 1 ]; then
         prompt_value SERVICE_USER "systemd service user" "$SERVICE_USER"
     fi
@@ -375,6 +381,13 @@ install_binaries() {
     tar -xzf "${WORKDIR}/${tarball}" -C "$WORKDIR"
     extracted="${WORKDIR}/scorpiofs-${VERSION}-${target}"
     [ -x "${extracted}/scorpio" ] && [ -x "${extracted}/antares" ] || die "release archive has an unexpected layout"
+    local smoke_output
+    if ! smoke_output="$("${extracted}/scorpio" --version 2>&1)"; then
+        die "downloaded scorpio cannot run on this host: ${smoke_output}. Install a release built for this Linux distribution"
+    fi
+    if ! smoke_output="$("${extracted}/antares" --version 2>&1)"; then
+        die "downloaded antares cannot run on this host: ${smoke_output}. Install a release built for this Linux distribution"
+    fi
     run_root install -d "${PREFIX}/bin"
     run_root install -m 0755 "${extracted}/scorpio" "${PREFIX}/bin/scorpio"
     run_root install -m 0755 "${extracted}/antares" "${PREFIX}/bin/antares"

--- a/install.sh
+++ b/install.sh
@@ -1049,14 +1049,38 @@ path_is_mount_target() {
 }
 
 recover_stale_runtime_mounts() {
-    local detach_managed_mounts="${1:-0}" mount_field mount_root i j duplicate
+    local detach_managed_mounts="${1:-0}" mount_field mount_root mount_target candidate_field
+    local mount_entries found i j duplicate
     local -a candidate_fields=(previous-workspace previous-antares-mount-root workspace antares-mount-root)
     local -a candidate_roots=("$PREVIOUS_WORKSPACE" "$PREVIOUS_ANTARES_MOUNT_ROOT" "$WORKSPACE" "$ANTARES_MOUNT_ROOT")
     local -a mount_fields=() mount_roots=()
     local -a probe
     for ((i = 0; i < ${#candidate_fields[@]}; i++)); do
+        candidate_field="${candidate_fields[$i]}"
         mount_root="${candidate_roots[$i]}"
         [ -n "$mount_root" ] || continue
+        if [[ "$candidate_field" == *antares-mount-root ]]; then
+            mount_entries="$(findmnt --noheadings --raw --output TARGET)" || \
+                die "could not inspect Antares mounts"
+            found=0
+            while IFS= read -r mount_target; do
+                case "$mount_target" in
+                    "$mount_root"|"$mount_root"/*)
+                        found=1
+                        duplicate=0
+                        for ((j = 0; j < ${#mount_roots[@]}; j++)); do
+                            if [ "${mount_roots[$j]}" = "$mount_target" ]; then duplicate=1; break; fi
+                        done
+                        if [ "$duplicate" -eq 0 ]; then
+                            mount_fields+=("$candidate_field")
+                            mount_roots+=("$mount_target")
+                        fi
+                        ;;
+                esac
+            done <<<"$mount_entries"
+            [ "$found" -eq 1 ] || continue
+            continue
+        fi
         duplicate=0
         for ((j = 0; j < ${#mount_roots[@]}; j++)); do
             if [ "${mount_roots[$j]}" = "$mount_root" ]; then duplicate=1; break; fi
@@ -1109,9 +1133,11 @@ recover_stale_runtime_mounts() {
                 die "could not detach stale $mount_field at $mount_root; install fuse3 or unmount it manually"
         fi
         [ "$DRY_RUN" -eq 1 ] && continue
-        path_is_mount_target "$mount_root" && \
+        if path_is_mount_target "$mount_root"; then
             die "stale $mount_field is still mounted at $mount_root; unmount it and retry"
+        fi
     done
+    return 0
 }
 
 validate_runtime_migration_mounts() {
@@ -1122,6 +1148,9 @@ validate_runtime_migration_mounts() {
         if [ -d "$runtime_dir" ]; then
             while IFS= read -r mount_target; do
                 case "$mount_target" in
+                    "$runtime_dir")
+                        die "refusing ownership migration across mount $mount_target at runtime directory; unmount it and retry"
+                        ;;
                     "$runtime_dir"/*)
                         die "refusing ownership migration across nested mount $mount_target under $runtime_dir; unmount it and retry"
                         ;;

--- a/install.sh
+++ b/install.sh
@@ -348,6 +348,36 @@ validate_runtime_paths() {
     done
     [ ! -L "$CONFIG_FILE" ] || die "runtime state file must not be a symbolic link: $CONFIG_FILE"
     [ ! -L "$ANTARES_STATE_FILE" ] || die "runtime state file must not be a symbolic link: $ANTARES_STATE_FILE"
+    validate_runtime_path_separation
+}
+
+paths_overlap() {
+    local left="$1" right="$2"
+    case "$left" in "$right"|"$right"/*) return 0 ;; esac
+    case "$right" in "$left"|"$left"/*) return 0 ;; esac
+    return 1
+}
+
+validate_runtime_path_separation() {
+    local mount_field mount_path persistent_field persistent_path i j
+    local -a mount_fields=(workspace antares-mount-root)
+    local -a mount_paths=("$WORKSPACE" "$ANTARES_MOUNT_ROOT")
+    local -a persistent_fields=(store-path config-file antares-upper-root antares-cl-root antares-state-file)
+    local -a persistent_paths=("$STORE_PATH" "$CONFIG_FILE" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT" "$ANTARES_STATE_FILE")
+    for ((i = 0; i < ${#mount_fields[@]}; i++)); do
+        mount_field="${mount_fields[$i]}"
+        mount_path="${mount_paths[$i]}"
+        for ((j = 0; j < ${#persistent_fields[@]}; j++)); do
+            persistent_field="${persistent_fields[$j]}"
+            persistent_path="${persistent_paths[$j]}"
+            if paths_overlap "$mount_path" "$persistent_path"; then
+                die "$mount_field must not overlap $persistent_field: $mount_path and $persistent_path"
+            fi
+        done
+    done
+    if paths_overlap "$WORKSPACE" "$ANTARES_MOUNT_ROOT"; then
+        die "workspace must not overlap antares-mount-root: $WORKSPACE and $ANTARES_MOUNT_ROOT"
+    fi
 }
 
 normalize_runtime_paths() {
@@ -422,7 +452,7 @@ set_generated_runtime_paths() {
 }
 
 run_scorpio_config_without_overrides() {
-    local binary="$1" variable
+    local binary="$1" variable config_path="${CONFDIR}/scorpio.toml"
     shift
     local -a command=(env)
     while IFS= read -r variable; do
@@ -431,7 +461,20 @@ run_scorpio_config_without_overrides() {
         esac
     done < <(compgen -e)
     if [ "$DRY_RUN" -eq 1 ]; then
-        "${command[@]}" "$binary" --config-path "${CONFDIR}/scorpio.toml" config "$@"
+        if [ "$(id -u)" -eq 0 ] || [ -r "${CONFDIR}/scorpio.toml" ]; then
+            "${command[@]}" "$binary" --config-path "${CONFDIR}/scorpio.toml" config "$@"
+        else
+            command -v sudo >/dev/null 2>&1 || \
+                die "sudo is required to read protected retained config during dry-run"
+            sudo -v || die "could not obtain read access for retained config during dry-run"
+            config_path="${WORKDIR}/retained-config.toml"
+            (umask 077; : >"$config_path") || \
+                die "could not create a protected config copy for retained dry-run"
+            if ! sudo cat -- "${CONFDIR}/scorpio.toml" | tee "$config_path" >/dev/null; then
+                die "could not read protected retained config during dry-run: ${CONFDIR}/scorpio.toml"
+            fi
+            "${command[@]}" "$binary" --config-path "$config_path" config "$@"
+        fi
     else
         run_root "${command[@]}" "$binary" --config-path "${CONFDIR}/scorpio.toml" config "$@"
     fi
@@ -757,6 +800,7 @@ validate_inputs() {
     validate_service_manager
     detect_existing_service_user
     validate_data_paths
+    validate_runtime_paths
     validate_bind "$HTTP_ADDR"
     is_loopback_host "$BIND_HOST" || [ "$ALLOW_PUBLIC_API" -eq 1 ] || \
         die "refusing non-loopback HTTP bind without --allow-public-api"

--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,11 @@ HTTP_ADDR="${SCORPIO_HTTP_ADDR:-127.0.0.1:2725}"
 GIT_AUTHOR="${SCORPIO_GIT_AUTHOR:-MEGA}"
 GIT_EMAIL="${SCORPIO_GIT_EMAIL:-admin@mega.org}"
 SERVICE_USER="${SCORPIO_SERVICE_USER:-scorpiofs}"
+CONFIG_FILE=""
+ANTARES_UPPER_ROOT=""
+ANTARES_CL_ROOT=""
+ANTARES_MOUNT_ROOT=""
+ANTARES_STATE_FILE=""
 
 DRY_RUN=0
 DO_UNINSTALL=0
@@ -43,6 +48,13 @@ OVERWRITE_CONFIG=0
 SERVICE_CHOICE_SET=0
 FUSE_CHOICE_SET=0
 CONFIG_CHOICE_SET=0
+DATA_ROOT_SET=0
+WORKSPACE_SET=0
+STORE_PATH_SET=0
+EXISTING_CONFIG=0
+RETAIN_CONFIG=0
+REQUESTED_WORKSPACE=""
+REQUESTED_STORE_PATH=""
 WORKDIR=""
 SUDO_BIN=""
 TARGET_USER=""
@@ -50,6 +62,10 @@ TARGET_GROUP=""
 TTY_FD=""
 BIND_HOST=""
 BIND_PORT=""
+
+[ -z "${SCORPIO_DATA_ROOT:-}" ] || DATA_ROOT_SET=1
+[ -z "${SCORPIO_WORKSPACE:-}" ] || WORKSPACE_SET=1
+[ -z "${SCORPIO_STORE_PATH:-}" ] || STORE_PATH_SET=1
 
 cleanup() {
     if [ -n "${WORKDIR:-}" ] && [ -d "$WORKDIR" ]; then
@@ -271,29 +287,165 @@ canonicalize_paths() {
     STORE_PATH="$(realpath -m -- "$STORE_PATH")"
 }
 
-validate_data_paths() {
+validate_data_root() {
     case "$DATA_ROOT" in
         /|/bin|/boot|/dev|/etc|/home|/lib|/lib64|/media|/mnt|/opt|/proc|/root|/run|/sbin|/srv|/sys|/tmp|/usr|/usr/local|/var|/var/lib|/var/log)
             die "data-root is too broad and must be a dedicated ScorpioFS directory: $DATA_ROOT"
             ;;
     esac
-    case "$WORKSPACE" in
+}
+
+require_path_in_data_root() {
+    local field="$1" value="$2"
+    case "$value" in
         "$DATA_ROOT"/*) ;;
-        *) die "workspace must be inside data-root ($DATA_ROOT): $WORKSPACE" ;;
+        *) die "$field must be inside data-root ($DATA_ROOT): $value" ;;
     esac
-    case "$STORE_PATH" in
-        "$DATA_ROOT"/*) ;;
-        *) die "store-path must be inside data-root ($DATA_ROOT): $STORE_PATH" ;;
-    esac
+}
+
+validate_data_paths() {
+    validate_data_root
+    require_path_in_data_root workspace "$WORKSPACE"
+    require_path_in_data_root store-path "$STORE_PATH"
     local runtime_file
     for runtime_file in "$DATA_ROOT/config.toml" "$DATA_ROOT/antares/state.toml"; do
         [ ! -L "$runtime_file" ] || die "runtime state file must not be a symbolic link: $runtime_file"
     done
     [ ! -L "$CONFDIR/scorpio.toml" ] || die "config file must not be a symbolic link: $CONFDIR/scorpio.toml"
-    if [ -d "$DATA_ROOT" ] && [ ! -f "$CONFDIR/scorpio.toml" ] && \
+    if [ -d "$DATA_ROOT" ] && [ "$EXISTING_CONFIG" -eq 0 ] && \
         [ -n "$(find "$DATA_ROOT" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
         die "refusing to change ownership of a nonempty data-root without an existing ScorpioFS config: $DATA_ROOT"
     fi
+}
+
+canonicalize_runtime_paths() {
+    WORKSPACE="$(realpath -m -- "$WORKSPACE")"
+    STORE_PATH="$(realpath -m -- "$STORE_PATH")"
+    CONFIG_FILE="$(realpath -m -- "$CONFIG_FILE")"
+    ANTARES_UPPER_ROOT="$(realpath -m -- "$ANTARES_UPPER_ROOT")"
+    ANTARES_CL_ROOT="$(realpath -m -- "$ANTARES_CL_ROOT")"
+    ANTARES_MOUNT_ROOT="$(realpath -m -- "$ANTARES_MOUNT_ROOT")"
+    ANTARES_STATE_FILE="$(realpath -m -- "$ANTARES_STATE_FILE")"
+}
+
+validate_runtime_paths() {
+    local field value i
+    local -a fields=(workspace store-path config-file antares-upper-root antares-cl-root antares-mount-root antares-state-file)
+    local -a values=("$WORKSPACE" "$STORE_PATH" "$CONFIG_FILE" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT" "$ANTARES_MOUNT_ROOT" "$ANTARES_STATE_FILE")
+    for ((i = 0; i < ${#fields[@]}; i++)); do
+        validate_path "${fields[$i]}" "${values[$i]}"
+    done
+    canonicalize_runtime_paths
+    values=("$WORKSPACE" "$STORE_PATH" "$CONFIG_FILE" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT" "$ANTARES_MOUNT_ROOT" "$ANTARES_STATE_FILE")
+    validate_data_root
+    for ((i = 0; i < ${#fields[@]}; i++)); do
+        field="${fields[$i]}"
+        value="${values[$i]}"
+        validate_path "$field" "$value"
+        require_path_in_data_root "$field" "$value"
+    done
+    [ ! -L "$CONFIG_FILE" ] || die "runtime state file must not be a symbolic link: $CONFIG_FILE"
+    [ ! -L "$ANTARES_STATE_FILE" ] || die "runtime state file must not be a symbolic link: $ANTARES_STATE_FILE"
+}
+
+normalize_runtime_paths() {
+    local i
+    local -a fields=(workspace store-path config-file antares-upper-root antares-cl-root antares-mount-root antares-state-file)
+    local -a values=("$WORKSPACE" "$STORE_PATH" "$CONFIG_FILE" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT" "$ANTARES_MOUNT_ROOT" "$ANTARES_STATE_FILE")
+    for ((i = 0; i < ${#fields[@]}; i++)); do
+        validate_path "${fields[$i]}" "${values[$i]}"
+    done
+    canonicalize_runtime_paths
+}
+
+common_path_ancestor() {
+    local candidate="$1" value
+    shift
+    for value in "$@"; do
+        while [ "$candidate" != "/" ]; do
+            case "$value" in
+                "$candidate"|"$candidate"/*) break ;;
+                *) candidate="${candidate%/*}"; [ -n "$candidate" ] || candidate="/" ;;
+            esac
+        done
+    done
+    printf '%s' "$candidate"
+}
+
+infer_data_root() {
+    DATA_ROOT="$(common_path_ancestor \
+        "$WORKSPACE" "$STORE_PATH" \
+        "$(dirname -- "$CONFIG_FILE")" \
+        "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT" "$ANTARES_MOUNT_ROOT" \
+        "$(dirname -- "$ANTARES_STATE_FILE")")"
+    note "using data-root inferred from retained config: $DATA_ROOT"
+}
+
+set_generated_runtime_paths() {
+    if [ "$WORKSPACE_SET" -eq 1 ]; then WORKSPACE="$REQUESTED_WORKSPACE"; else WORKSPACE="$DATA_ROOT/mount"; fi
+    if [ "$STORE_PATH_SET" -eq 1 ]; then STORE_PATH="$REQUESTED_STORE_PATH"; else STORE_PATH="$DATA_ROOT/store"; fi
+    CONFIG_FILE="$DATA_ROOT/config.toml"
+    ANTARES_UPPER_ROOT="$DATA_ROOT/antares/upper"
+    ANTARES_CL_ROOT="$DATA_ROOT/antares/cl"
+    ANTARES_MOUNT_ROOT="$DATA_ROOT/antares/mnt"
+    ANTARES_STATE_FILE="$DATA_ROOT/antares/state.toml"
+}
+
+load_configured_runtime_paths() {
+    local binary="$1" output_file="${WORKDIR}/installer-paths"
+    local -a paths=()
+    if ! run_root env \
+        -u SCORPIO_WORKSPACE \
+        -u SCORPIO_STORE_PATH \
+        -u SCORPIO_CONFIG_FILE \
+        -u SCORPIO_ANTARES_UPPER_ROOT \
+        -u SCORPIO_ANTARES_CL_ROOT \
+        -u SCORPIO_ANTARES_MOUNT_ROOT \
+        -u SCORPIO_ANTARES_STATE_FILE \
+        "$binary" --config-path "${CONFDIR}/scorpio.toml" config installer-paths >"$output_file"; then
+        die "could not safely resolve runtime paths from retained config: ${CONFDIR}/scorpio.toml"
+    fi
+    mapfile -d '' -t paths <"$output_file"
+    [ "${#paths[@]}" -eq 7 ] || die "installer received an invalid runtime-path response from scorpio"
+    WORKSPACE="${paths[0]}"
+    STORE_PATH="${paths[1]}"
+    CONFIG_FILE="${paths[2]}"
+    ANTARES_UPPER_ROOT="${paths[3]}"
+    ANTARES_CL_ROOT="${paths[4]}"
+    ANTARES_MOUNT_ROOT="${paths[5]}"
+    ANTARES_STATE_FILE="${paths[6]}"
+}
+
+prepare_effective_runtime_paths() {
+    local binary="$1" selected_root_nonempty=0 load_existing_paths=0
+    if [ -d "$DATA_ROOT" ] && [ -n "$(find "$DATA_ROOT" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+        selected_root_nonempty=1
+    fi
+
+    if [ "$RETAIN_CONFIG" -eq 1 ]; then
+        load_existing_paths=1
+    elif [ "$EXISTING_CONFIG" -eq 1 ] && \
+        { [ "$DATA_ROOT_SET" -eq 0 ] || [ "$selected_root_nonempty" -eq 1 ]; }; then
+        # Before overwriting a nonempty root, prove that the old config belongs
+        # to it. An unspecified root is inferred from that same old config.
+        load_existing_paths=1
+    fi
+
+    if [ "$load_existing_paths" -eq 1 ]; then
+        load_configured_runtime_paths "$binary"
+        normalize_runtime_paths
+        if [ "$DATA_ROOT_SET" -eq 0 ]; then infer_data_root; fi
+        validate_runtime_paths
+    fi
+
+    if [ "$RETAIN_CONFIG" -eq 1 ]; then
+        note "using runtime paths from retained ${CONFDIR}/scorpio.toml"
+        return 0
+    fi
+
+    set_generated_runtime_paths
+    canonicalize_runtime_paths
+    validate_runtime_paths
 }
 
 validate_bind() {
@@ -344,11 +496,11 @@ parse_args() {
             --release-base-url) [ "$#" -ge 2 ] || die "--release-base-url needs a value"; RELEASE_BASE_URL="$2"; shift 2 ;;
             --prefix) [ "$#" -ge 2 ] || die "--prefix needs a value"; PREFIX="$2"; shift 2 ;;
             --config-dir) [ "$#" -ge 2 ] || die "--config-dir needs a value"; CONFDIR="$2"; shift 2 ;;
-            --data-root) [ "$#" -ge 2 ] || die "--data-root needs a value"; DATA_ROOT="$2"; shift 2 ;;
+            --data-root) [ "$#" -ge 2 ] || die "--data-root needs a value"; DATA_ROOT="$2"; DATA_ROOT_SET=1; shift 2 ;;
             --base-url) [ "$#" -ge 2 ] || die "--base-url needs a value"; BASE_URL="$2"; shift 2 ;;
             --lfs-url) [ "$#" -ge 2 ] || die "--lfs-url needs a value"; LFS_URL="$2"; shift 2 ;;
-            --workspace) [ "$#" -ge 2 ] || die "--workspace needs a value"; WORKSPACE="$2"; shift 2 ;;
-            --store-path) [ "$#" -ge 2 ] || die "--store-path needs a value"; STORE_PATH="$2"; shift 2 ;;
+            --workspace) [ "$#" -ge 2 ] || die "--workspace needs a value"; WORKSPACE="$2"; WORKSPACE_SET=1; shift 2 ;;
+            --store-path) [ "$#" -ge 2 ] || die "--store-path needs a value"; STORE_PATH="$2"; STORE_PATH_SET=1; shift 2 ;;
             --http-addr) [ "$#" -ge 2 ] || die "--http-addr needs a value"; HTTP_ADDR="$2"; shift 2 ;;
             --allow-public-api) ALLOW_PUBLIC_API=1; shift ;;
             --no-service) SETUP_SERVICE=0; SERVICE_CHOICE_SET=1; shift ;;
@@ -460,9 +612,16 @@ configure_interactively() {
     printf 'The remote HTTP API is unauthenticated and will default to loopback.\n\n'
     prompt_value BASE_URL "Mega/monorepo base URL" "${BASE_URL:-http://localhost:8000}"
     prompt_value LFS_URL "Git LFS URL" "${LFS_URL:-$(normalize_url "$BASE_URL")/lfs}"
+    local previous_data_root="$DATA_ROOT" workspace_default="${WORKSPACE:-$DATA_ROOT/mount}"
+    local store_default="${STORE_PATH:-$DATA_ROOT/store}"
     prompt_value DATA_ROOT "Data root" "$DATA_ROOT"
-    prompt_value WORKSPACE "FUSE workspace" "${WORKSPACE:-$DATA_ROOT/mount}"
-    prompt_value STORE_PATH "Local store/cache" "${STORE_PATH:-$DATA_ROOT/store}"
+    [ "$DATA_ROOT" = "$previous_data_root" ] || DATA_ROOT_SET=1
+    workspace_default="${WORKSPACE:-$DATA_ROOT/mount}"
+    store_default="${STORE_PATH:-$DATA_ROOT/store}"
+    prompt_value WORKSPACE "FUSE workspace" "$workspace_default"
+    [ "$WORKSPACE" = "$workspace_default" ] || WORKSPACE_SET=1
+    prompt_value STORE_PATH "Local store/cache" "$store_default"
+    [ "$STORE_PATH" = "$store_default" ] || STORE_PATH_SET=1
     prompt_value HTTP_ADDR "HTTP listen address" "$HTTP_ADDR"
     prompt_value GIT_AUTHOR "Default Git author" "$GIT_AUTHOR"
     prompt_value GIT_EMAIL "Default Git email" "$GIT_EMAIL"
@@ -504,11 +663,16 @@ validate_inputs() {
     validate_path workspace "$WORKSPACE"
     validate_path store-path "$STORE_PATH"
     canonicalize_paths
+    canonicalize_runtime_paths
     validate_path prefix "$PREFIX"
     validate_path config-dir "$CONFDIR"
     validate_path data-root "$DATA_ROOT"
     validate_path workspace "$WORKSPACE"
     validate_path store-path "$STORE_PATH"
+    if [ -f "${CONFDIR}/scorpio.toml" ]; then
+        EXISTING_CONFIG=1
+        if [ "$OVERWRITE_CONFIG" -ne 1 ]; then RETAIN_CONFIG=1; fi
+    fi
     validate_data_paths
     validate_bind "$HTTP_ADDR"
     is_loopback_host "$BIND_HOST" || [ "$ALLOW_PUBLIC_API" -eq 1 ] || \
@@ -564,6 +728,7 @@ install_binaries() {
     if ! smoke_output="$("${extracted}/antares" --version 2>&1)"; then
         die "downloaded antares cannot run on this host: ${smoke_output}. Install a release built for this Linux distribution"
     fi
+    prepare_effective_runtime_paths "${extracted}/scorpio"
     run_root install -d "${PREFIX}/bin"
     run_root install -m 0755 "${extracted}/scorpio" "${PREFIX}/bin/scorpio"
     run_root install -m 0755 "${extracted}/antares" "${PREFIX}/bin/antares"
@@ -604,14 +769,14 @@ prepare_directories() {
     fi
     run_root install -d -o "$TARGET_USER" -g "$TARGET_GROUP" \
         "$DATA_ROOT" "$WORKSPACE" "$STORE_PATH" \
-        "$DATA_ROOT/antares" "$DATA_ROOT/antares/upper" \
-        "$DATA_ROOT/antares/cl" "$DATA_ROOT/antares/mnt"
+        "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT" "$ANTARES_MOUNT_ROOT" \
+        "$(dirname -- "$CONFIG_FILE")" "$(dirname -- "$ANTARES_STATE_FILE")"
     run_root install -d "$CONFDIR"
 }
 
 reconcile_runtime_files() {
     local runtime_file
-    for runtime_file in "$DATA_ROOT/config.toml" "$DATA_ROOT/antares/state.toml"; do
+    for runtime_file in "$CONFIG_FILE" "$ANTARES_STATE_FILE"; do
         if [ -e "$runtime_file" ]; then
             run_root chown "$TARGET_USER:$TARGET_GROUP" "$runtime_file"
         fi
@@ -639,15 +804,19 @@ write_config() {
         return 0
     fi
     local escaped_base_url escaped_lfs_url escaped_workspace escaped_store_path
-    local escaped_config_file escaped_author escaped_email escaped_data_root
+    local escaped_config_file escaped_author escaped_email
+    local escaped_antares_upper escaped_antares_cl escaped_antares_mount escaped_antares_state
     escaped_base_url="$(toml_escape "$BASE_URL")"
     escaped_lfs_url="$(toml_escape "$LFS_URL")"
     escaped_workspace="$(toml_escape "$WORKSPACE")"
     escaped_store_path="$(toml_escape "$STORE_PATH")"
-    escaped_config_file="$(toml_escape "$DATA_ROOT/config.toml")"
+    escaped_config_file="$(toml_escape "$CONFIG_FILE")"
     escaped_author="$(toml_escape "$GIT_AUTHOR")"
     escaped_email="$(toml_escape "$GIT_EMAIL")"
-    escaped_data_root="$(toml_escape "$DATA_ROOT")"
+    escaped_antares_upper="$(toml_escape "$ANTARES_UPPER_ROOT")"
+    escaped_antares_cl="$(toml_escape "$ANTARES_CL_ROOT")"
+    escaped_antares_mount="$(toml_escape "$ANTARES_MOUNT_ROOT")"
+    escaped_antares_state="$(toml_escape "$ANTARES_STATE_FILE")"
     umask 077
     cat > "$config_tmp" <<EOF
 # Generated by ScorpioFS install.sh. Edit base_url/lfs_url when the backend changes.
@@ -659,10 +828,10 @@ config_file = "$escaped_config_file"
 git_author = "$escaped_author"
 git_email = "$escaped_email"
 log_level = "info"
-antares_upper_root = "$escaped_data_root/antares/upper"
-antares_cl_root = "$escaped_data_root/antares/cl"
-antares_mount_root = "$escaped_data_root/antares/mnt"
-antares_state_file = "$escaped_data_root/antares/state.toml"
+antares_upper_root = "$escaped_antares_upper"
+antares_cl_root = "$escaped_antares_cl"
+antares_mount_root = "$escaped_antares_mount"
+antares_state_file = "$escaped_antares_state"
 EOF
     run_root install -m 0640 -o "$TARGET_USER" -g "$TARGET_GROUP" "$config_tmp" "${CONFDIR}/scorpio.toml"
     rm -f "$config_tmp"
@@ -720,7 +889,7 @@ AmbientCapabilities=CAP_SYS_ADMIN
 CapabilityBoundingSet=CAP_SYS_ADMIN
 WorkingDirectory=${DATA_ROOT}
 ExecStart=${PREFIX}/bin/scorpio --config-path ${CONFDIR}/scorpio.toml serve --http-addr ${HTTP_ADDR}
-ExecStopPost=-/bin/sh -c 'for m in \$(findmnt -rno TARGET --submounts ${DATA_ROOT}/antares/mnt 2>/dev/null | sort -r); do fusermount3 -u -z "\$m"; done'
+ExecStopPost=-/bin/sh -c 'for m in \$(findmnt -rno TARGET --submounts ${ANTARES_MOUNT_ROOT} 2>/dev/null | sort -r); do fusermount3 -u -z "\$m"; done'
 ExecStopPost=-/usr/bin/fusermount3 -u -z ${WORKSPACE}
 Restart=on-failure
 RestartSec=5s
@@ -773,6 +942,9 @@ main() {
     if [ -z "$LFS_URL" ]; then LFS_URL="$(normalize_url "$BASE_URL")/lfs"; fi
     if [ -z "$WORKSPACE" ]; then WORKSPACE="$DATA_ROOT/mount"; fi
     if [ -z "$STORE_PATH" ]; then STORE_PATH="$DATA_ROOT/store"; fi
+    REQUESTED_WORKSPACE="$WORKSPACE"
+    REQUESTED_STORE_PATH="$STORE_PATH"
+    set_generated_runtime_paths
     validate_inputs
     require_privileges
 

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 REPO="gitmono-dev/scorpiofs"
 VERSION="${SCORPIO_VERSION:-}"
+RELEASE_BASE_URL="${SCORPIO_RELEASE_BASE_URL:-https://github.com/${REPO}/releases/download}"
 PREFIX="${SCORPIO_PREFIX:-/usr/local}"
 CONFDIR="${SCORPIO_CONFDIR:-/etc/scorpiofs}"
 DATA_ROOT="${SCORPIO_DATA_ROOT:-/var/lib/scorpiofs}"
@@ -62,6 +63,7 @@ HTTP bind address, FUSE permission, and whether to install a systemd service.
 
 Options:
   --version <vX.Y.Z>        Release tag (default: latest GitHub release).
+  --release-base-url <url>  Release mirror root (default: GitHub releases).
   --prefix <dir>            Binary prefix (default: /usr/local).
   --config-dir <dir>        Config directory (default: /etc/scorpiofs).
   --data-root <dir>         Runtime/data root (default: /var/lib/scorpiofs).
@@ -198,6 +200,7 @@ parse_args() {
     while [ "$#" -gt 0 ]; do
         case "$1" in
             --version) [ "$#" -ge 2 ] || die "--version needs a value"; VERSION="$2"; shift 2 ;;
+            --release-base-url) [ "$#" -ge 2 ] || die "--release-base-url needs a value"; RELEASE_BASE_URL="$2"; shift 2 ;;
             --prefix) [ "$#" -ge 2 ] || die "--prefix needs a value"; PREFIX="$2"; shift 2 ;;
             --config-dir) [ "$#" -ge 2 ] || die "--config-dir needs a value"; CONFDIR="$2"; shift 2 ;;
             --data-root) [ "$#" -ge 2 ] || die "--data-root needs a value"; DATA_ROOT="$2"; shift 2 ;;
@@ -331,6 +334,7 @@ validate_inputs() {
     LFS_URL="$(normalize_url "$LFS_URL")"
     validate_url base_url "$BASE_URL"
     validate_url lfs_url "$LFS_URL"
+    validate_url release-base-url "$RELEASE_BASE_URL"
     validate_path prefix "$PREFIX"
     validate_path config-dir "$CONFDIR"
     validate_path data-root "$DATA_ROOT"
@@ -350,7 +354,7 @@ install_binaries() {
     local target tarball base url sumurl extracted
     target="$(detect_target)"
     tarball="scorpiofs-${VERSION}-${target}.tar.gz"
-    base="https://github.com/${REPO}/releases/download/${VERSION}"
+    base="${RELEASE_BASE_URL%/}/${VERSION}"
     url="${base}/${tarball}"
     sumurl="${url}.sha256"
 

--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,7 @@ WORKSPACE_SET=0
 STORE_PATH_SET=0
 EXISTING_CONFIG=0
 RETAIN_CONFIG=0
+EXISTING_SERVICE_USER=""
 REQUESTED_WORKSPACE=""
 REQUESTED_STORE_PATH=""
 WORKDIR=""
@@ -353,9 +354,20 @@ normalize_runtime_paths() {
     local -a fields=(workspace store-path config-file antares-upper-root antares-cl-root antares-mount-root antares-state-file)
     local -a values=("$WORKSPACE" "$STORE_PATH" "$CONFIG_FILE" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT" "$ANTARES_MOUNT_ROOT" "$ANTARES_STATE_FILE")
     for ((i = 0; i < ${#fields[@]}; i++)); do
-        validate_path "${fields[$i]}" "${values[$i]}"
+        validate_runtime_path_value "${fields[$i]}" "${values[$i]}"
     done
-    canonicalize_runtime_paths
+}
+
+validate_runtime_path_value() {
+    local field="$1" value="$2"
+    [ -n "$value" ] || die "$field must not be empty"
+    [[ "$value" != *[[:space:]]* ]] || die "$field must not contain whitespace"
+    [[ "$value" =~ ^/?[A-Za-z0-9._+:/-]+$ ]] || \
+        die "$field contains a character unsafe for shell or systemd use"
+    [[ "$value" != *'//'* ]] || die "$field must not contain repeated slashes"
+    case "/${value#/}/" in
+        *'/../'*|*'/./'*) die "$field must not contain . or .. path components" ;;
+    esac
 }
 
 common_path_ancestor() {
@@ -373,12 +385,29 @@ common_path_ancestor() {
 }
 
 infer_data_root() {
-    DATA_ROOT="$(common_path_ancestor \
-        "$WORKSPACE" "$STORE_PATH" \
-        "$(dirname -- "$CONFIG_FILE")" \
-        "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT" "$ANTARES_MOUNT_ROOT" \
-        "$(dirname -- "$ANTARES_STATE_FILE")")"
+    local value
+    local -a anchors=()
+    for value in "$WORKSPACE" "$STORE_PATH" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT" "$ANTARES_MOUNT_ROOT"; do
+        if [[ "$value" == /* ]]; then anchors+=("$(dirname -- "$value")"); fi
+    done
+    for value in "$CONFIG_FILE" "$ANTARES_STATE_FILE"; do
+        if [[ "$value" == /* ]]; then anchors+=("$(dirname -- "$value")"); fi
+    done
+    [ "${#anchors[@]}" -gt 0 ] || \
+        die "cannot infer data-root from an all-relative retained config; pass --data-root"
+    DATA_ROOT="$(common_path_ancestor "${anchors[@]}")"
     note "using data-root inferred from retained config: $DATA_ROOT"
+}
+
+resolve_relative_runtime_paths() {
+    if [[ "$WORKSPACE" != /* ]]; then WORKSPACE="$DATA_ROOT/$WORKSPACE"; fi
+    if [[ "$STORE_PATH" != /* ]]; then STORE_PATH="$DATA_ROOT/$STORE_PATH"; fi
+    if [[ "$CONFIG_FILE" != /* ]]; then CONFIG_FILE="$DATA_ROOT/$CONFIG_FILE"; fi
+    if [[ "$ANTARES_UPPER_ROOT" != /* ]]; then ANTARES_UPPER_ROOT="$DATA_ROOT/$ANTARES_UPPER_ROOT"; fi
+    if [[ "$ANTARES_CL_ROOT" != /* ]]; then ANTARES_CL_ROOT="$DATA_ROOT/$ANTARES_CL_ROOT"; fi
+    if [[ "$ANTARES_MOUNT_ROOT" != /* ]]; then ANTARES_MOUNT_ROOT="$DATA_ROOT/$ANTARES_MOUNT_ROOT"; fi
+    if [[ "$ANTARES_STATE_FILE" != /* ]]; then ANTARES_STATE_FILE="$DATA_ROOT/$ANTARES_STATE_FILE"; fi
+    canonicalize_runtime_paths
 }
 
 set_generated_runtime_paths() {
@@ -435,6 +464,7 @@ prepare_effective_runtime_paths() {
         load_configured_runtime_paths "$binary"
         normalize_runtime_paths
         if [ "$DATA_ROOT_SET" -eq 0 ]; then infer_data_root; fi
+        resolve_relative_runtime_paths
         validate_runtime_paths
     fi
 
@@ -446,6 +476,23 @@ prepare_effective_runtime_paths() {
     set_generated_runtime_paths
     canonicalize_runtime_paths
     validate_runtime_paths
+}
+
+detect_existing_service_user() {
+    [ "$SETUP_SERVICE" -eq 0 ] && [ "$EXISTING_CONFIG" -eq 1 ] || return 0
+    local candidate=""
+    if command -v systemctl >/dev/null 2>&1; then
+        candidate="$(systemctl show --property=User --value scorpiofs.service 2>/dev/null || true)"
+    fi
+    if [ -z "$candidate" ] && [ -r /etc/systemd/system/scorpiofs.service ]; then
+        candidate="$(awk -F= '$1 == "User" { print $2; exit }' /etc/systemd/system/scorpiofs.service)"
+    fi
+    [ -n "$candidate" ] || return 0
+    [[ "$candidate" =~ ^([a-z_][a-z0-9_-]{0,31}|[0-9]+)$ ]] || \
+        die "existing scorpiofs.service has an unsupported User value: $candidate"
+    getent passwd "$candidate" >/dev/null 2>&1 || \
+        die "existing scorpiofs.service user does not exist: $candidate"
+    EXISTING_SERVICE_USER="$candidate"
 }
 
 validate_bind() {
@@ -673,6 +720,7 @@ validate_inputs() {
         EXISTING_CONFIG=1
         if [ "$OVERWRITE_CONFIG" -ne 1 ]; then RETAIN_CONFIG=1; fi
     fi
+    detect_existing_service_user
     validate_data_paths
     validate_bind "$HTTP_ADDR"
     is_loopback_host "$BIND_HOST" || [ "$ALLOW_PUBLIC_API" -eq 1 ] || \
@@ -764,14 +812,32 @@ prepare_directories() {
             TARGET_GROUP="$SERVICE_USER"
         fi
     else
-        TARGET_USER="${SUDO_USER:-$(id -un)}"
-        TARGET_GROUP="$(id -gn "$TARGET_USER" 2>/dev/null || id -gn)"
+        if [ -n "$EXISTING_SERVICE_USER" ]; then
+            TARGET_USER="$EXISTING_SERVICE_USER"
+            TARGET_GROUP="$(id -gn "$TARGET_USER")" || \
+                die "could not determine the primary group for existing service user $TARGET_USER"
+            note "preserving ownership for existing scorpiofs.service user: $TARGET_USER"
+        else
+            TARGET_USER="${SUDO_USER:-$(id -un)}"
+            TARGET_GROUP="$(id -gn "$TARGET_USER" 2>/dev/null || id -gn)"
+        fi
     fi
     run_root install -d -o "$TARGET_USER" -g "$TARGET_GROUP" \
         "$DATA_ROOT" "$WORKSPACE" "$STORE_PATH" \
         "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT" "$ANTARES_MOUNT_ROOT" \
         "$(dirname -- "$CONFIG_FILE")" "$(dirname -- "$ANTARES_STATE_FILE")"
     run_root install -d "$CONFDIR"
+}
+
+reconcile_runtime_directories() {
+    local runtime_dir
+    # These are persistent local data trees. Workspace and mount roots are
+    # intentionally excluded because they may currently be FUSE mountpoints.
+    for runtime_dir in "$STORE_PATH" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT"; do
+        if [ -d "$runtime_dir" ]; then
+            run_root chown -R -h -P "$TARGET_USER:$TARGET_GROUP" -- "$runtime_dir"
+        fi
+    done
 }
 
 reconcile_runtime_files() {
@@ -954,6 +1020,7 @@ main() {
     install_binaries
     ensure_service_account
     prepare_directories
+    reconcile_runtime_directories
     reconcile_runtime_files
     write_config
     validate_installed_config
@@ -967,7 +1034,7 @@ main() {
     if [ "$SETUP_SERVICE" -eq 1 ]; then
         note "logs:   journalctl -u scorpiofs -f"
     else
-        note "run:    ${PREFIX}/bin/scorpio --config-path ${CONFDIR}/scorpio.toml serve --http-addr ${HTTP_ADDR}"
+        note "run:    cd ${DATA_ROOT} && ${PREFIX}/bin/scorpio --config-path ${CONFDIR}/scorpio.toml serve --http-addr ${HTTP_ADDR}"
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -57,6 +57,12 @@ EXISTING_SERVICE_USER=""
 EXISTING_SERVICE_ACTIVE=0
 SERVICE_STOPPED_FOR_UPGRADE=0
 SERVICE_HEALTH_CONFIRMED=0
+ARTIFACT_BACKUP_DIR=""
+ARTIFACT_BACKUP_READY=0
+HAD_OLD_SCORPIO=0
+HAD_OLD_ANTARES=0
+HAD_OLD_CONFIG=0
+HAD_OLD_UNIT=0
 PREVIOUS_WORKSPACE=""
 PREVIOUS_ANTARES_MOUNT_ROOT=""
 EXTRACTED_RELEASE=""
@@ -78,6 +84,11 @@ cleanup() {
     local exit_status=$?
     if [ "$exit_status" -ne 0 ] && [ "$SERVICE_STOPPED_FOR_UPGRADE" -eq 1 ] && \
         [ "$SERVICE_HEALTH_CONFIRMED" -ne 1 ] && command -v systemctl >/dev/null 2>&1; then
+        if [ "$ARTIFACT_BACKUP_READY" -eq 1 ]; then
+            if ! restore_upgrade_artifacts; then
+                warn "could not restore all previous ScorpioFS artifacts"
+            fi
+        fi
         warn "installation failed after stopping scorpiofs.service; attempting to restore the managed service"
         if ! run_root systemctl start scorpiofs.service; then
             warn "could not restore scorpiofs.service; inspect: systemctl status scorpiofs"
@@ -924,7 +935,7 @@ validate_inputs() {
 }
 
 prepare_release_binaries() {
-    local target tarball base url sumurl extracted installed_binary
+    local target tarball base url sumurl
     target="$(detect_target)"
     tarball="scorpiofs-${VERSION}-${target}.tar.gz"
     base="${RELEASE_BASE_URL%/}/${VERSION}"
@@ -933,18 +944,27 @@ prepare_release_binaries() {
 
     if [ "$DRY_RUN" -eq 1 ]; then
         if [ "$EXISTING_CONFIG" -eq 1 ]; then
-            installed_binary="${PREFIX}/bin/scorpio"
-            [ -x "$installed_binary" ] || \
-                die "dry-run cannot faithfully resolve retained config without $installed_binary"
-            WORKDIR="$(mktemp -d)"
-            prepare_effective_runtime_paths "$installed_binary"
+            prepare_release_archive
+            prepare_effective_runtime_paths "${EXTRACTED_RELEASE}/scorpio"
+        else
+            note "would download ${url}"
+            note "would verify ${sumurl} with SHA256"
         fi
-        note "would download ${url}"
-        note "would verify ${sumurl} with SHA256"
         note "would install ${PREFIX}/bin/scorpio and ${PREFIX}/bin/antares"
         return 0
     fi
 
+    prepare_release_archive
+    prepare_effective_runtime_paths "${EXTRACTED_RELEASE}/scorpio"
+}
+
+prepare_release_archive() {
+    local target tarball base url sumurl extracted
+    target="$(detect_target)"
+    tarball="scorpiofs-${VERSION}-${target}.tar.gz"
+    base="${RELEASE_BASE_URL%/}/${VERSION}"
+    url="${base}/${tarball}"
+    sumurl="${url}.sha256"
     WORKDIR="$(mktemp -d)"
     note "downloading ${tarball}"
     fetch "$url" "${WORKDIR}/${tarball}" || die "release asset unavailable for ${target} and ${VERSION}"
@@ -974,7 +994,6 @@ prepare_release_binaries() {
     if ! smoke_output="$("${extracted}/antares" --version 2>&1)"; then
         die "downloaded antares cannot run on this host: ${smoke_output}. Install a release built for this Linux distribution"
     fi
-    prepare_effective_runtime_paths "${extracted}/scorpio"
     EXTRACTED_RELEASE="$extracted"
 }
 
@@ -987,6 +1006,60 @@ install_release_binaries() {
     run_root install -d "${PREFIX}/bin"
     run_root install -m 0755 "${EXTRACTED_RELEASE}/scorpio" "${PREFIX}/bin/scorpio"
     run_root install -m 0755 "${EXTRACTED_RELEASE}/antares" "${PREFIX}/bin/antares"
+}
+
+backup_upgrade_artifacts() {
+    [ "$SERVICE_STOPPED_FOR_UPGRADE" -eq 1 ] || return 0
+    [ -n "$WORKDIR" ] || die "internal error: upgrade backup requires a working directory"
+    ARTIFACT_BACKUP_DIR="${WORKDIR}/previous-install"
+    mkdir -m 0700 -- "$ARTIFACT_BACKUP_DIR"
+    if run_root test -e "${PREFIX}/bin/scorpio"; then
+        HAD_OLD_SCORPIO=1
+        run_root cp -a -- "${PREFIX}/bin/scorpio" "${ARTIFACT_BACKUP_DIR}/scorpio"
+    fi
+    if run_root test -e "${PREFIX}/bin/antares"; then
+        HAD_OLD_ANTARES=1
+        run_root cp -a -- "${PREFIX}/bin/antares" "${ARTIFACT_BACKUP_DIR}/antares"
+    fi
+    if run_root test -e "${CONFDIR}/scorpio.toml"; then
+        HAD_OLD_CONFIG=1
+        run_root cp -a -- "${CONFDIR}/scorpio.toml" "${ARTIFACT_BACKUP_DIR}/scorpio.toml"
+    fi
+    if run_root test -e /etc/systemd/system/scorpiofs.service; then
+        HAD_OLD_UNIT=1
+        run_root cp -a -- /etc/systemd/system/scorpiofs.service \
+            "${ARTIFACT_BACKUP_DIR}/scorpiofs.service"
+    fi
+    ARTIFACT_BACKUP_READY=1
+}
+
+restore_upgrade_artifact() {
+    local had_old="$1" backup="$2" target="$3"
+    if ! run_root rm -f -- "$target"; then
+        return 1
+    fi
+    if [ "$had_old" -eq 1 ]; then
+        run_root test -f "$backup" || return 1
+        run_root cp -a -- "$backup" "$target"
+    fi
+}
+
+restore_upgrade_artifacts() {
+    local restore_failed=0
+    warn "restoring ScorpioFS artifacts from before the failed upgrade"
+    restore_upgrade_artifact "$HAD_OLD_SCORPIO" \
+        "${ARTIFACT_BACKUP_DIR}/scorpio" "${PREFIX}/bin/scorpio" || restore_failed=1
+    restore_upgrade_artifact "$HAD_OLD_ANTARES" \
+        "${ARTIFACT_BACKUP_DIR}/antares" "${PREFIX}/bin/antares" || restore_failed=1
+    restore_upgrade_artifact "$HAD_OLD_CONFIG" \
+        "${ARTIFACT_BACKUP_DIR}/scorpio.toml" "${CONFDIR}/scorpio.toml" || restore_failed=1
+    restore_upgrade_artifact "$HAD_OLD_UNIT" \
+        "${ARTIFACT_BACKUP_DIR}/scorpiofs.service" \
+        /etc/systemd/system/scorpiofs.service || restore_failed=1
+    if [ "$HAD_OLD_UNIT" -eq 1 ]; then
+        run_root systemctl daemon-reload || restore_failed=1
+    fi
+    [ "$restore_failed" -eq 0 ]
 }
 
 ensure_service_account() {
@@ -1007,6 +1080,15 @@ ensure_service_account() {
         run_root usermod -aG fuse "$SERVICE_USER"
     else
         warn "fuse group does not exist; the service may not be able to access /dev/fuse"
+    fi
+}
+
+validate_service_config_traversal() {
+    [ "$SETUP_SERVICE" -eq 1 ] || return 0
+    [ "$EXISTING_CONFIG" -eq 1 ] || return 0
+    [ "$DRY_RUN" -eq 0 ] || return 0
+    if ! run_root runuser -u "$SERVICE_USER" -- test -x "$CONFDIR"; then
+        die "service user $SERVICE_USER cannot traverse config-dir $CONFDIR; grant directory execute access before changing service users"
     fi
 }
 
@@ -1265,7 +1347,14 @@ validate_installed_config() {
 
 validate_user_allow_other() {
     [ "$ENABLE_USER_ALLOW_OTHER" -eq 1 ] && return 0
-    if run_root grep -qE '^[[:space:]]*user_allow_other[[:space:]]*$' /etc/fuse.conf 2>/dev/null; then
+    if [ "$DRY_RUN" -eq 1 ] && [ "$(id -u)" -ne 0 ] && \
+        [ -e /etc/fuse.conf ] && [ ! -r /etc/fuse.conf ]; then
+        command -v sudo >/dev/null 2>&1 || \
+            die "sudo is required to inspect protected /etc/fuse.conf during dry-run"
+        sudo -v || die "could not obtain read access for /etc/fuse.conf during dry-run"
+        SUDO_BIN="sudo"
+    fi
+    if run_readonly grep -qE '^[[:space:]]*user_allow_other[[:space:]]*$' /etc/fuse.conf 2>/dev/null; then
         note "using the existing user_allow_other setting in /etc/fuse.conf"
         return 0
     fi
@@ -1409,8 +1498,10 @@ main() {
     recover_stale_runtime_mounts
     validate_runtime_migration_mounts
     ensure_service_account
+    validate_service_config_traversal
     stop_active_service_for_upgrade
     recover_stale_runtime_mounts "$SERVICE_STOPPED_FOR_UPGRADE"
+    backup_upgrade_artifacts
     install_release_binaries
     prepare_directories
     reconcile_runtime_directories

--- a/install.sh
+++ b/install.sh
@@ -65,6 +65,7 @@ HAD_OLD_CONFIG=0
 HAD_OLD_UNIT=0
 PREVIOUS_WORKSPACE=""
 PREVIOUS_ANTARES_MOUNT_ROOT=""
+PREVIOUS_DATA_ROOT=""
 PREVIOUS_STORE_PATH=""
 PREVIOUS_ANTARES_UPPER_ROOT=""
 PREVIOUS_ANTARES_CL_ROOT=""
@@ -89,6 +90,12 @@ cleanup() {
     local exit_status=$?
     if [ "$exit_status" -ne 0 ] && [ "$SERVICE_STOPPED_FOR_UPGRADE" -eq 1 ] && \
         [ "$SERVICE_HEALTH_CONFIRMED" -ne 1 ] && command -v systemctl >/dev/null 2>&1; then
+        if run_root systemctl is-active --quiet scorpiofs.service; then
+            warn "stopping the failed replacement service before rollback"
+            if ! run_root systemctl stop scorpiofs.service; then
+                warn "could not stop the failed replacement service before rollback"
+            fi
+        fi
         if [ "$ARTIFACT_BACKUP_READY" -eq 1 ]; then
             if ! restore_upgrade_artifacts; then
                 warn "could not restore all previous ScorpioFS artifacts"
@@ -182,7 +189,11 @@ require_privileges() {
         return 0
     fi
     command -v sudo >/dev/null 2>&1 || die "root privileges are required; install sudo or run as root"
-    sudo -v || die "could not obtain sudo privileges"
+    if [ "$INTERACTIVE" -eq 1 ]; then
+        sudo -v || die "could not obtain sudo privileges"
+    else
+        sudo -n -v || die "could not obtain non-interactive sudo privileges; run as root or pre-authorize sudo"
+    fi
     SUDO_BIN="sudo"
 }
 
@@ -342,8 +353,18 @@ validate_data_root() {
 data_root_is_nonempty() {
     [ -d "$DATA_ROOT" ] || return 1
     local data_root_entry
-    if ! data_root_entry="$(find "$DATA_ROOT" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)"; then
-        die "could not inspect data-root; refusing to change ownership without verifying it is empty: $DATA_ROOT"
+    if ! data_root_entry="$(run_readonly find "$DATA_ROOT" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)"; then
+        if [ "$(id -u)" -ne 0 ] && [ -z "$SUDO_BIN" ]; then
+            command -v sudo >/dev/null 2>&1 || \
+                die "could not inspect data-root; refusing to change ownership without verifying it is empty: $DATA_ROOT"
+            sudo -n -v || \
+                die "could not inspect data-root; refusing to change ownership without verifying it is empty: $DATA_ROOT"
+            SUDO_BIN="sudo"
+            data_root_entry="$(run_readonly find "$DATA_ROOT" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" || \
+                die "could not inspect data-root; refusing to change ownership without verifying it is empty: $DATA_ROOT"
+        else
+            die "could not inspect data-root; refusing to change ownership without verifying it is empty: $DATA_ROOT"
+        fi
     fi
     [ -n "$data_root_entry" ]
 }
@@ -592,6 +613,8 @@ prepare_effective_runtime_paths() {
                 die "cannot safely use a nonempty data-root with an all-relative retained config; pass the previous data-root or empty the new root"
             DATA_ROOT="$target_data_root"
         elif [ "$RETAIN_CONFIG" -eq 1 ]; then
+            retained_config_has_absolute_anchor || \
+                die "cannot safely use an empty data-root with an all-relative retained config; pass --overwrite-config or use the previous data-root"
             DATA_ROOT="$target_data_root"
         else
             infer_data_root \
@@ -602,6 +625,10 @@ prepare_effective_runtime_paths() {
         validate_runtime_paths
         PREVIOUS_WORKSPACE="$WORKSPACE"
         PREVIOUS_ANTARES_MOUNT_ROOT="$ANTARES_MOUNT_ROOT"
+        PREVIOUS_DATA_ROOT="$(common_path_ancestor \
+            "$(dirname -- "$WORKSPACE")" "$(dirname -- "$STORE_PATH")" \
+            "$(dirname -- "$CONFIG_FILE")" "$(dirname -- "$ANTARES_UPPER_ROOT")" \
+            "$(dirname -- "$ANTARES_CL_ROOT")" "$(dirname -- "$ANTARES_STATE_FILE")")"
         PREVIOUS_STORE_PATH="$STORE_PATH"
         PREVIOUS_ANTARES_UPPER_ROOT="$ANTARES_UPPER_ROOT"
         PREVIOUS_ANTARES_CL_ROOT="$ANTARES_CL_ROOT"
@@ -1081,6 +1108,10 @@ restore_runtime_ownership() {
 
     local previous_group runtime_dir runtime_file restore_failed=0
     previous_group="$(id -gn "$EXISTING_SERVICE_USER")" || return 1
+    if [ -n "$PREVIOUS_DATA_ROOT" ] && run_root test -d "$PREVIOUS_DATA_ROOT" && \
+        ! run_root chown "$EXISTING_SERVICE_USER:$previous_group" -- "$PREVIOUS_DATA_ROOT"; then
+        restore_failed=1
+    fi
     for runtime_dir in "$PREVIOUS_STORE_PATH" "$PREVIOUS_ANTARES_UPPER_ROOT" \
         "$PREVIOUS_ANTARES_CL_ROOT"; do
         [ -n "$runtime_dir" ] || continue
@@ -1480,15 +1511,23 @@ wait_for_service_health() {
             die "scorpiofs.service is not active after starting; inspect: systemctl status scorpiofs"
         fi
         if [ "$DOWNLOADER" = "curl" ]; then
-            if curl -fsS --noproxy '*' --connect-timeout 2 --max-time 5 "$endpoint" >/dev/null 2>&1; then
+            if curl -fsS --noproxy '*' --connect-timeout 2 --max-time 5 "$endpoint" >/dev/null 2>&1 && \
+                run_root systemctl is-active --quiet scorpiofs.service; then
+                sleep 1
+                if run_root systemctl is-active --quiet scorpiofs.service; then
+                    SERVICE_HEALTH_CONFIRMED=1
+                    note "scorpiofs.service is healthy at ${endpoint}"
+                    return 0
+                fi
+            fi
+        elif wget -q --no-proxy --timeout=2 --tries=1 -O /dev/null "$endpoint" && \
+            run_root systemctl is-active --quiet scorpiofs.service; then
+            sleep 1
+            if run_root systemctl is-active --quiet scorpiofs.service; then
                 SERVICE_HEALTH_CONFIRMED=1
                 note "scorpiofs.service is healthy at ${endpoint}"
                 return 0
             fi
-        elif wget -q --no-proxy --timeout=2 --tries=1 -O /dev/null "$endpoint"; then
-            SERVICE_HEALTH_CONFIRMED=1
-            note "scorpiofs.service is healthy at ${endpoint}"
-            return 0
         fi
         sleep 1
     done
@@ -1523,8 +1562,8 @@ main() {
     REQUESTED_WORKSPACE="$WORKSPACE"
     REQUESTED_STORE_PATH="$STORE_PATH"
     set_generated_runtime_paths
-    validate_inputs
     require_privileges
+    validate_inputs
     validate_user_allow_other
 
     note "installing ScorpioFS ${VERSION} for $(detect_target)"

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,7 @@ STORE_PATH_SET=0
 EXISTING_CONFIG=0
 RETAIN_CONFIG=0
 EXISTING_SERVICE_USER=""
+EXISTING_SERVICE_ACTIVE=0
 SERVICE_STOPPED_FOR_UPGRADE=0
 PREVIOUS_WORKSPACE=""
 PREVIOUS_ANTARES_MOUNT_ROOT=""
@@ -309,6 +310,15 @@ validate_data_root() {
     esac
 }
 
+data_root_is_nonempty() {
+    [ -d "$DATA_ROOT" ] || return 1
+    local data_root_entry
+    if ! data_root_entry="$(find "$DATA_ROOT" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)"; then
+        die "could not inspect data-root; refusing to change ownership without verifying it is empty: $DATA_ROOT"
+    fi
+    [ -n "$data_root_entry" ]
+}
+
 require_path_in_data_root() {
     local field="$1" value="$2"
     case "$value" in
@@ -326,13 +336,8 @@ validate_data_paths() {
         [ ! -L "$runtime_file" ] || die "runtime state file must not be a symbolic link: $runtime_file"
     done
     [ ! -L "$CONFDIR/scorpio.toml" ] || die "config file must not be a symbolic link: $CONFDIR/scorpio.toml"
-    if [ -d "$DATA_ROOT" ] && [ "$EXISTING_CONFIG" -eq 0 ]; then
-        local data_root_entry
-        if ! data_root_entry="$(find "$DATA_ROOT" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)"; then
-            die "could not inspect data-root; refusing to change ownership without verifying it is empty: $DATA_ROOT"
-        fi
-        [ -z "$data_root_entry" ] || \
-            die "refusing to change ownership of a nonempty data-root without an existing ScorpioFS config: $DATA_ROOT"
+    if [ "$EXISTING_CONFIG" -eq 0 ] && data_root_is_nonempty; then
+        die "refusing to change ownership of a nonempty data-root without an existing ScorpioFS config: $DATA_ROOT"
     fi
 }
 
@@ -466,6 +471,15 @@ infer_data_root() {
     note "using $root_label inferred from retained config: $DATA_ROOT"
 }
 
+retained_config_has_absolute_anchor() {
+    local value
+    for value in "$WORKSPACE" "$STORE_PATH" "$CONFIG_FILE" "$ANTARES_UPPER_ROOT" \
+        "$ANTARES_CL_ROOT" "$ANTARES_MOUNT_ROOT" "$ANTARES_STATE_FILE"; do
+        [[ "$value" == /* ]] && return 0
+    done
+    return 1
+}
+
 resolve_relative_runtime_paths() {
     if [[ "$WORKSPACE" != /* ]]; then WORKSPACE="$DATA_ROOT/$WORKSPACE"; fi
     if [[ "$STORE_PATH" != /* ]]; then STORE_PATH="$DATA_ROOT/$STORE_PATH"; fi
@@ -535,7 +549,7 @@ load_configured_runtime_paths() {
 
 prepare_effective_runtime_paths() {
     local binary="$1" selected_root_nonempty=0 target_data_root="$DATA_ROOT"
-    if [ -d "$DATA_ROOT" ] && [ -n "$(find "$DATA_ROOT" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+    if data_root_is_nonempty; then
         selected_root_nonempty=1
     fi
 
@@ -544,7 +558,11 @@ prepare_effective_runtime_paths() {
         normalize_runtime_paths
         if [ "$DATA_ROOT_SET" -eq 0 ]; then
             infer_data_root
-        elif [ "$RETAIN_CONFIG" -eq 1 ] || [ "$selected_root_nonempty" -eq 1 ]; then
+        elif [ "$selected_root_nonempty" -eq 1 ]; then
+            retained_config_has_absolute_anchor || \
+                die "cannot safely use a nonempty data-root with an all-relative retained config; pass the previous data-root or empty the new root"
+            DATA_ROOT="$target_data_root"
+        elif [ "$RETAIN_CONFIG" -eq 1 ]; then
             DATA_ROOT="$target_data_root"
         else
             infer_data_root \
@@ -582,6 +600,10 @@ detect_existing_service_user() {
     getent passwd "$candidate" >/dev/null 2>&1 || \
         die "existing scorpiofs.service user does not exist: $candidate"
     EXISTING_SERVICE_USER="$candidate"
+    if command -v systemctl >/dev/null 2>&1 && \
+        systemctl is-active --quiet scorpiofs.service 2>/dev/null; then
+        EXISTING_SERVICE_ACTIVE=1
+    fi
 }
 
 stop_active_service_for_upgrade() {
@@ -1066,7 +1088,8 @@ recover_stale_runtime_mounts() {
             probe_succeeded=1
         fi
         if [ "$probe_succeeded" -eq 1 ] && [ "$detach_managed_mounts" -ne 1 ]; then
-            if [ "$SETUP_SERVICE" -eq 1 ] && [ -z "$EXISTING_SERVICE_USER" ]; then
+            if [ "$SETUP_SERVICE" -eq 1 ] && \
+                { [ -z "$EXISTING_SERVICE_USER" ] || [ "$EXISTING_SERVICE_ACTIVE" -ne 1 ]; }; then
                 die "$mount_field is actively mounted at $mount_root by an unmanaged process; stop the ScorpioFS daemon, unmount this path, and retry"
             fi
             note "$mount_field is actively mounted; leaving the mount root unchanged during directory preparation"

--- a/install.sh
+++ b/install.sh
@@ -1,39 +1,53 @@
 #!/usr/bin/env bash
 #
-# ScorpioFS installer.
+# ScorpioFS interactive installer.
 #
-# Downloads a release binary tarball (scorpio + antares), verifies its SHA256
-# checksum, installs the binaries, and generates a baseline config. System
-# package installation and any /etc/fuse.conf change are explicit, never silent.
+# With no arguments this script asks for the Mega/monorepo URLs, local paths,
+# HTTP bind address, and whether to install a systemd service. It also keeps a
+# non-interactive mode for automation and the original release-install flags.
 #
-# Quick (convenience) path:
-#   curl -fsSL https://raw.githubusercontent.com/gitmono-dev/scorpiofs/main/install.sh | bash -s -- --version v0.3.0
+# Interactive use (including curl | bash):
+#   curl -fsSL https://raw.githubusercontent.com/gitmono-dev/scorpiofs/main/install.sh | bash
 #
-# Safer path (download, inspect, then run):
+# Safer use:
 #   curl -fsSLO https://raw.githubusercontent.com/gitmono-dev/scorpiofs/main/install.sh
 #   less install.sh
-#   bash install.sh --version v0.3.0
+#   bash install.sh
 #
 set -euo pipefail
 
 REPO="gitmono-dev/scorpiofs"
-VERSION=""
-PREFIX="/usr/local"
-CONFDIR="/etc/scorpiofs"
+VERSION="${SCORPIO_VERSION:-}"
+PREFIX="${SCORPIO_PREFIX:-/usr/local}"
+CONFDIR="${SCORPIO_CONFDIR:-/etc/scorpiofs}"
+DATA_ROOT="${SCORPIO_DATA_ROOT:-/var/lib/scorpiofs}"
+BASE_URL="${SCORPIO_BASE_URL:-}"
+LFS_URL="${SCORPIO_LFS_URL:-}"
+WORKSPACE="${SCORPIO_WORKSPACE:-}"
+STORE_PATH="${SCORPIO_STORE_PATH:-}"
+HTTP_ADDR="${SCORPIO_HTTP_ADDR:-127.0.0.1:2725}"
+GIT_AUTHOR="${SCORPIO_GIT_AUTHOR:-MEGA}"
+GIT_EMAIL="${SCORPIO_GIT_EMAIL:-admin@mega.org}"
+SERVICE_USER="${SCORPIO_SERVICE_USER:-scorpiofs}"
+
 DRY_RUN=0
 DO_UNINSTALL=0
 INSTALL_DEPS=1
 ENABLE_USER_ALLOW_OTHER=0
+SETUP_SERVICE=1
+INTERACTIVE=1
+ASSUME_YES=0
+ALLOW_PUBLIC_API=0
+OVERWRITE_CONFIG=0
 WORKDIR=""
+SUDO_BIN=""
+TARGET_USER=""
+TARGET_GROUP=""
 
-# Clean up the download workdir on exit. Guarded so it is a no-op (returning 0)
-# when nothing was created — otherwise a failed test would leak into the script's
-# exit status — and it never removes anything in --dry-run.
 cleanup() {
-    if [ "$DRY_RUN" -eq 0 ] && [ -n "${WORKDIR:-}" ]; then
+    if [ -n "${WORKDIR:-}" ] && [ -d "$WORKDIR" ]; then
         rm -rf "$WORKDIR"
     fi
-    return 0
 }
 trap cleanup EXIT
 
@@ -41,16 +55,37 @@ usage() {
     cat <<'EOF'
 Usage: install.sh [options]
 
-Options:
-  --version <vX.Y.Z>        Release tag to install (required unless --uninstall).
-  --prefix <dir>            Install prefix (default: /usr/local; binaries go to <prefix>/bin).
-  --dry-run                 Print every action without making changes.
-  --uninstall               Remove installed binaries (keeps config and data).
-  --no-deps                 Skip system package installation.
-  --enable-user-allow-other Append 'user_allow_other' to /etc/fuse.conf (off by default).
-  -h, --help                Show this help.
+Interactive mode is the default. It asks for the remote URLs, local paths,
+HTTP bind address, FUSE permission, and whether to install a systemd service.
 
-Exit codes: 0 success; non-zero on error (dependency, download, or checksum failure).
+Options:
+  --version <vX.Y.Z>        Release tag (default: latest GitHub release).
+  --prefix <dir>            Binary prefix (default: /usr/local).
+  --config-dir <dir>        Config directory (default: /etc/scorpiofs).
+  --data-root <dir>         Runtime/data root (default: /var/lib/scorpiofs).
+  --base-url <url>          Mega/monorepo service URL.
+  --lfs-url <url>           Git LFS endpoint URL.
+  --workspace <dir>         FUSE workspace directory.
+  --store-path <dir>        Local cache/store directory.
+  --http-addr <ip:port>     HTTP API bind address (default: 127.0.0.1:2725).
+  --allow-public-api        Permit a non-loopback HTTP bind (use a firewall/auth proxy).
+  --no-service              Do not create or start a systemd service.
+  --non-interactive         Use arguments/environment without prompting.
+  --yes                     Accept safe defaults in interactive mode.
+  --dry-run                 Print actions without changing the system.
+  --uninstall               Stop/remove binaries and the systemd unit; keep data.
+  --no-deps                 Skip system package installation.
+  --enable-user-allow-other Enable user_allow_other in /etc/fuse.conf.
+  --no-user-allow-other     Do not change /etc/fuse.conf.
+  -h, --help                Show this help message.
+
+Examples:
+  sudo bash install.sh
+  bash install.sh --base-url https://mega.example.com --lfs-url https://mega.example.com/lfs
+  bash install.sh --version v0.4.0 --non-interactive --dry-run
+
+The HTTP API has no authentication. The installer therefore defaults to
+127.0.0.1 and asks for explicit confirmation before accepting a public bind.
 EOF
 }
 
@@ -58,193 +93,475 @@ note() { printf '==> %s\n' "$*"; }
 warn() { printf 'WARN: %s\n' "$*" >&2; }
 die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
-# run <cmd...> : execute, or just print in dry-run mode.
-run() {
+run_root() {
     if [ "$DRY_RUN" -eq 1 ]; then
-        printf '  [dry-run] %s\n' "$*"
+        printf '  [dry-run]'
+        if [ -n "$SUDO_BIN" ]; then printf ' %s' "$SUDO_BIN"; fi
+        printf ' %s\n' "$*"
+        return 0
+    fi
+    if [ -n "$SUDO_BIN" ]; then
+        "$SUDO_BIN" "$@"
     else
         "$@"
     fi
 }
 
-require_root() {
-    if [ "$(id -u)" -ne 0 ] && [ "$DRY_RUN" -eq 0 ]; then
-        die "this step needs root; re-run with sudo (or use --dry-run to preview)"
+require_privileges() {
+    [ "$DRY_RUN" -eq 1 ] && return 0
+    if [ "$(id -u)" -eq 0 ]; then
+        SUDO_BIN=""
+        return 0
     fi
+    command -v sudo >/dev/null 2>&1 || die "root privileges are required; install sudo or run as root"
+    sudo -v || die "could not obtain sudo privileges"
+    SUDO_BIN="sudo"
+}
+
+read_tty() {
+    if [ -r /dev/tty ]; then
+        IFS= read -r REPLY </dev/tty || REPLY=""
+    else
+        IFS= read -r REPLY || REPLY=""
+    fi
+}
+
+prompt_value() {
+    local variable="$1" label="$2" default="$3"
+    if [ "$ASSUME_YES" -eq 1 ]; then
+        printf -v "$variable" '%s' "$default"
+        return 0
+    fi
+    printf '%s [%s]: ' "$label" "$default" >/dev/tty 2>/dev/null || printf '%s [%s]: ' "$label" "$default"
+    read_tty
+    if [ -z "$REPLY" ]; then REPLY="$default"; fi
+    printf -v "$variable" '%s' "$REPLY"
+}
+
+prompt_yes_no() {
+    local variable="$1" label="$2" default="$3" answer=""
+    if [ "$ASSUME_YES" -eq 1 ]; then
+        case "$default" in
+            y|Y|yes|YES|Yes) printf -v "$variable" '%s' 1 ;;
+            *) printf -v "$variable" '%s' 0 ;;
+        esac
+        return 0
+    fi
+    while :; do
+        printf '%s [%s]: ' "$label" "$default" >/dev/tty 2>/dev/null || printf '%s [%s]: ' "$label" "$default"
+        read_tty
+        answer="${REPLY:-$default}"
+        case "$answer" in
+            y|Y|yes|YES|Yes) printf -v "$variable" '%s' 1; return 0 ;;
+            n|N|no|NO|No)    printf -v "$variable" '%s' 0; return 0 ;;
+            *) printf 'Please answer yes or no.\n' >&2 ;;
+        esac
+    done
+}
+
+validate_url() {
+    local field="$1" value="$2"
+    case "$value" in
+        http://*|https://*) ;;
+        *) die "$field must start with http:// or https:// (got: $value)" ;;
+    esac
+    [[ "$value" != *[[:space:]]* ]] || die "$field must not contain whitespace"
+    [[ "$value" != *'"'* ]] || die "$field must not contain a double quote"
+    [[ "$value" != *"'"* ]] || die "$field must not contain a single quote"
+    [[ "$value" != *'`'* && "$value" != *'\\'* ]] || die "$field contains an unsafe character"
+}
+
+validate_path() {
+    local field="$1" value="$2"
+    [ -n "$value" ] || die "$field must not be empty"
+    [[ "$value" == /* ]] || die "$field must be an absolute path: $value"
+    [[ "$value" != *[[:space:]]* ]] || die "$field must not contain whitespace"
+    [[ "$value" != *$'\n'* && "$value" != *$'\r'* ]] || die "$field must not contain a newline"
+    [[ "$value" != *'"'* && "$value" != *'`'* && "$value" != *'$'* && "$value" != *'\\'* ]] || die "$field contains an unsafe shell character"
+}
+
+validate_bind() {
+    local value="$1"
+    [[ "$value" =~ ^(127\.0\.0\.1|0\.0\.0\.0|::1|\[::1\]):[0-9]{1,5}$ ]] || \
+        die "--http-addr must be an IPv4/IPv6 loopback or wildcard address such as 127.0.0.1:2725"
+}
+
+normalize_url() {
+    local value="$1"
+    while [ "${value%/}" != "$value" ]; do value="${value%/}"; done
+    printf '%s' "$value"
+}
+
+parse_args() {
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --version) [ "$#" -ge 2 ] || die "--version needs a value"; VERSION="$2"; shift 2 ;;
+            --prefix) [ "$#" -ge 2 ] || die "--prefix needs a value"; PREFIX="$2"; shift 2 ;;
+            --config-dir) [ "$#" -ge 2 ] || die "--config-dir needs a value"; CONFDIR="$2"; shift 2 ;;
+            --data-root) [ "$#" -ge 2 ] || die "--data-root needs a value"; DATA_ROOT="$2"; shift 2 ;;
+            --base-url) [ "$#" -ge 2 ] || die "--base-url needs a value"; BASE_URL="$2"; shift 2 ;;
+            --lfs-url) [ "$#" -ge 2 ] || die "--lfs-url needs a value"; LFS_URL="$2"; shift 2 ;;
+            --workspace) [ "$#" -ge 2 ] || die "--workspace needs a value"; WORKSPACE="$2"; shift 2 ;;
+            --store-path) [ "$#" -ge 2 ] || die "--store-path needs a value"; STORE_PATH="$2"; shift 2 ;;
+            --http-addr) [ "$#" -ge 2 ] || die "--http-addr needs a value"; HTTP_ADDR="$2"; shift 2 ;;
+            --allow-public-api) ALLOW_PUBLIC_API=1; shift ;;
+            --no-service) SETUP_SERVICE=0; shift ;;
+            --non-interactive) INTERACTIVE=0; shift ;;
+            --yes) ASSUME_YES=1; shift ;;
+            --dry-run) DRY_RUN=1; shift ;;
+            --uninstall) DO_UNINSTALL=1; INTERACTIVE=0; shift ;;
+            --no-deps) INSTALL_DEPS=0; shift ;;
+            --enable-user-allow-other) ENABLE_USER_ALLOW_OTHER=1; shift ;;
+            --no-user-allow-other) ENABLE_USER_ALLOW_OTHER=0; shift ;;
+            -h|--help) usage; exit 0 ;;
+            *) die "unknown option: $1 (see --help)" ;;
+        esac
+    done
 }
 
 detect_target() {
-    local arch
-    arch="$(uname -m)"
-    case "$arch" in
-        x86_64|amd64)  echo "x86_64-unknown-linux-gnu" ;;
+    case "$(uname -m)" in
+        x86_64|amd64) echo "x86_64-unknown-linux-gnu" ;;
         aarch64|arm64) echo "aarch64-unknown-linux-musl" ;;
-        *) die "unsupported architecture: $arch" ;;
+        *) die "unsupported architecture: $(uname -m)" ;;
     esac
 }
 
-pkg_install() {
-    # Install runtime dependencies via the detected package manager. We install
-    # the `openssl` package (rather than a version-specific `libssl3` / `libssl3t64`)
-    # so the correct OpenSSL runtime is pulled regardless of the distro release.
-    local pkgs_apt="fuse3 openssl ca-certificates"
-    local pkgs_dnf="fuse3 openssl ca-certificates"
-    local pkgs_pacman="fuse3 openssl ca-certificates"
-
-    if command -v apt-get >/dev/null 2>&1; then
-        require_root
-        run apt-get update
-        run apt-get install -y --no-install-recommends $pkgs_apt
-    elif command -v dnf >/dev/null 2>&1; then
-        require_root
-        run dnf install -y $pkgs_dnf
-    elif command -v pacman >/dev/null 2>&1; then
-        require_root
-        run pacman -Sy --noconfirm $pkgs_pacman
+check_tools() {
+    if command -v curl >/dev/null 2>&1; then
+        DOWNLOADER="curl"
+    elif command -v wget >/dev/null 2>&1; then
+        DOWNLOADER="wget"
     else
-        warn "no supported package manager (apt/dnf/pacman) found; install fuse3 + openssl + ca-certificates manually"
+        die "curl or wget is required"
     fi
-}
-
-maybe_enable_user_allow_other() {
-    [ "$ENABLE_USER_ALLOW_OTHER" -eq 1 ] || return 0
-    require_root
-    if [ -f /etc/fuse.conf ] && grep -qE '^[[:space:]]*user_allow_other[[:space:]]*$' /etc/fuse.conf; then
-        note "/etc/fuse.conf already has user_allow_other"
-        return 0
-    fi
-    note "enabling user_allow_other in /etc/fuse.conf (explicitly requested)"
-    if [ "$DRY_RUN" -eq 1 ]; then
-        printf "  [dry-run] echo 'user_allow_other' >> /etc/fuse.conf\n"
-    else
-        printf 'user_allow_other\n' >> /etc/fuse.conf
-    fi
+    command -v tar >/dev/null 2>&1 || die "tar is required"
 }
 
 fetch() {
-    # fetch <url> <dest>
     local url="$1" dest="$2"
-    if command -v curl >/dev/null 2>&1; then
-        run curl -fsSL "$url" -o "$dest"
-    elif command -v wget >/dev/null 2>&1; then
-        run wget -qO "$dest" "$url"
+    if [ "$DOWNLOADER" = "curl" ]; then
+        curl -fsSL --connect-timeout 10 --max-time 300 "$url" -o "$dest"
     else
-        die "need curl or wget to download release assets"
+        wget -q --timeout=30 --tries=3 "$url" -O "$dest"
     fi
 }
 
+resolve_version() {
+    [ -n "$VERSION" ] && return 0
+    note "resolving the latest ScorpioFS release"
+    local release_json
+    if [ "$DOWNLOADER" = "curl" ]; then
+        release_json="$(curl -fsSL --connect-timeout 10 --max-time 30 "https://api.github.com/repos/${REPO}/releases/latest")" \
+            || die "could not query the latest release; pass --version vX.Y.Z"
+    else
+        release_json="$(wget -q --timeout=30 --tries=3 -O - "https://api.github.com/repos/${REPO}/releases/latest")" \
+            || die "could not query the latest release; pass --version vX.Y.Z"
+    fi
+    VERSION="$(printf '%s' "$release_json" | awk -F'"' '/"tag_name"[[:space:]]*:/ { print $4; exit }')"
+    [ -n "$VERSION" ] || die "GitHub returned no release tag; pass --version vX.Y.Z"
+}
+
+normalize_version() {
+    [[ "$VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9.+-]*$ ]] || die "invalid version: $VERSION"
+    case "$VERSION" in v*) ;; *) VERSION="v$VERSION" ;; esac
+}
+
+pkg_install() {
+    [ "$INSTALL_DEPS" -eq 1 ] || { note "skipping dependency installation (--no-deps)"; return 0; }
+    if command -v apt-get >/dev/null 2>&1; then
+        run_root apt-get update
+        run_root apt-get install -y --no-install-recommends fuse3 openssl ca-certificates
+    elif command -v dnf >/dev/null 2>&1; then
+        run_root dnf install -y fuse3 openssl ca-certificates
+    elif command -v pacman >/dev/null 2>&1; then
+        run_root pacman -Sy --noconfirm fuse3 openssl ca-certificates
+    else
+        warn "no supported package manager found; install fuse3, openssl, and ca-certificates manually"
+    fi
+}
+
+check_fuse() {
+    if [ ! -e /dev/fuse ] && command -v modprobe >/dev/null 2>&1; then
+        run_root modprobe fuse 2>/dev/null || true
+    fi
+    [ -e /dev/fuse ] || warn "/dev/fuse is missing; ScorpioFS will not mount until FUSE is enabled"
+    command -v fusermount3 >/dev/null 2>&1 || warn "fusermount3 is missing; verify the fuse3 package installation"
+}
+
+configure_interactively() {
+    [ "$INTERACTIVE" -eq 1 ] || return 0
+    printf '\nScorpioFS interactive installer\n'
+    printf 'The remote HTTP API is unauthenticated and will default to loopback.\n\n'
+    prompt_value BASE_URL "Mega/monorepo base URL" "${BASE_URL:-http://localhost:8000}"
+    prompt_value LFS_URL "Git LFS URL" "${LFS_URL:-$(normalize_url "$BASE_URL")/lfs}"
+    prompt_value DATA_ROOT "Data root" "$DATA_ROOT"
+    prompt_value WORKSPACE "FUSE workspace" "${WORKSPACE:-$DATA_ROOT/mount}"
+    prompt_value STORE_PATH "Local store/cache" "${STORE_PATH:-$DATA_ROOT/store}"
+    prompt_value HTTP_ADDR "HTTP listen address" "$HTTP_ADDR"
+    prompt_value GIT_AUTHOR "Default Git author" "$GIT_AUTHOR"
+    prompt_value GIT_EMAIL "Default Git email" "$GIT_EMAIL"
+    prompt_yes_no ENABLE_USER_ALLOW_OTHER "Enable user_allow_other in /etc/fuse.conf" "y"
+    prompt_yes_no SETUP_SERVICE "Install and start systemd service" "y"
+    if [ "$SETUP_SERVICE" -eq 1 ]; then
+        prompt_value SERVICE_USER "systemd service user" "$SERVICE_USER"
+    fi
+    if [ -f "${CONFDIR}/scorpio.toml" ]; then
+        prompt_yes_no OVERWRITE_CONFIG "Overwrite existing ${CONFDIR}/scorpio.toml" "n"
+    fi
+
+    case "$HTTP_ADDR" in
+        127.0.0.1:*|::1:*|\[::1\]:*) ;;
+        *)
+            warn "${HTTP_ADDR} is not loopback. ScorpioFS has no HTTP authentication."
+            prompt_yes_no PUBLIC_API_OK "Continue with an externally reachable API only behind a firewall/auth proxy" "n"
+            if [ "$PUBLIC_API_OK" -eq 1 ]; then ALLOW_PUBLIC_API=1; else HTTP_ADDR="127.0.0.1:2725"; fi
+            ;;
+    esac
+}
+
+validate_inputs() {
+    BASE_URL="$(normalize_url "$BASE_URL")"
+    LFS_URL="$(normalize_url "$LFS_URL")"
+    validate_url base_url "$BASE_URL"
+    validate_url lfs_url "$LFS_URL"
+    validate_path prefix "$PREFIX"
+    validate_path config-dir "$CONFDIR"
+    validate_path data-root "$DATA_ROOT"
+    validate_path workspace "$WORKSPACE"
+    validate_path store-path "$STORE_PATH"
+    validate_bind "$HTTP_ADDR"
+    case "$HTTP_ADDR" in
+        127.0.0.1:*|::1:*|\[::1\]:*) ;;
+        *) [ "$ALLOW_PUBLIC_API" -eq 1 ] || die "refusing non-loopback HTTP bind without --allow-public-api" ;;
+    esac
+    [[ "$GIT_AUTHOR" != *$'\n'* && "$GIT_AUTHOR" != *'"'* ]] || die "git author contains an unsafe character"
+    [[ "$GIT_EMAIL" != *$'\n'* && "$GIT_EMAIL" != *'"'* ]] || die "git email contains an unsafe character"
+    [[ "$SERVICE_USER" =~ ^[a-z_][a-z0-9_-]{0,31}$ ]] || die "invalid service user: $SERVICE_USER"
+}
+
 install_binaries() {
-    local target tarball base url sumurl tmp
+    local target tarball base url sumurl extracted
     target="$(detect_target)"
     tarball="scorpiofs-${VERSION}-${target}.tar.gz"
     base="https://github.com/${REPO}/releases/download/${VERSION}"
     url="${base}/${tarball}"
     sumurl="${url}.sha256"
 
-    # In --dry-run use a synthetic path so we make no filesystem changes at all.
     if [ "$DRY_RUN" -eq 1 ]; then
-        WORKDIR="/tmp/scorpiofs-install.dryrun"
-    else
-        WORKDIR="$(mktemp -d)"
+        note "would download ${url}"
+        note "would verify ${sumurl} with SHA256"
+        note "would install ${PREFIX}/bin/scorpio and ${PREFIX}/bin/antares"
+        return 0
     fi
-    tmp="$WORKDIR"
 
+    WORKDIR="$(mktemp -d)"
     note "downloading ${tarball}"
-    fetch "$url" "${tmp}/${tarball}"
-    note "downloading checksum"
-    fetch "$sumurl" "${tmp}/${tarball}.sha256"
-
+    fetch "$url" "${WORKDIR}/${tarball}" || die "release asset unavailable for ${target} and ${VERSION}"
+    fetch "$sumurl" "${WORKDIR}/${tarball}.sha256" || die "release checksum unavailable: ${sumurl}"
     note "verifying SHA256 checksum"
-    if [ "$DRY_RUN" -eq 1 ]; then
-        printf '  [dry-run] sha256sum -c %s\n' "${tarball}.sha256"
+    if command -v sha256sum >/dev/null 2>&1; then
+        (cd "$WORKDIR" && sha256sum -c "${tarball}.sha256") || die "checksum verification failed"
+    elif command -v shasum >/dev/null 2>&1; then
+        local expected actual
+        expected="$(awk '{print $1; exit}' "${WORKDIR}/${tarball}.sha256")"
+        actual="$(shasum -a 256 "${WORKDIR}/${tarball}" | awk '{print $1}')"
+        [ "$expected" = "$actual" ] || die "checksum verification failed"
     else
-        ( cd "$tmp" && sha256sum -c "${tarball}.sha256" ) \
-            || die "checksum verification failed — refusing to install"
+        die "sha256sum or shasum is required for checksum verification"
     fi
 
     note "extracting and installing to ${PREFIX}/bin"
-    run tar -xzf "${tmp}/${tarball}" -C "$tmp"
-    run install -d "${PREFIX}/bin"
-    # Tarball layout: scorpiofs-<version>-<target>/{scorpio,antares,LICENSE,README}
-    run install -m 0755 "${tmp}/scorpiofs-${VERSION}-${target}/scorpio" "${PREFIX}/bin/scorpio"
-    run install -m 0755 "${tmp}/scorpiofs-${VERSION}-${target}/antares" "${PREFIX}/bin/antares"
+    tar -xzf "${WORKDIR}/${tarball}" -C "$WORKDIR"
+    extracted="${WORKDIR}/scorpiofs-${VERSION}-${target}"
+    [ -x "${extracted}/scorpio" ] && [ -x "${extracted}/antares" ] || die "release archive has an unexpected layout"
+    run_root install -d "${PREFIX}/bin"
+    run_root install -m 0755 "${extracted}/scorpio" "${PREFIX}/bin/scorpio"
+    run_root install -m 0755 "${extracted}/antares" "${PREFIX}/bin/antares"
 }
 
-generate_config() {
-    note "ensuring config at ${CONFDIR}/scorpio.toml"
-    run install -d "$CONFDIR"
-    if [ -f "${CONFDIR}/scorpio.toml" ]; then
-        note "config already exists; leaving it unchanged"
+ensure_service_account() {
+    [ "$SETUP_SERVICE" -eq 1 ] || return 0
+    if [ "$DRY_RUN" -eq 1 ]; then
+        TARGET_USER="$SERVICE_USER"
+        TARGET_GROUP="$SERVICE_USER"
+        note "would create system user ${SERVICE_USER} and add it to the fuse group"
+        return 0
+    fi
+    if ! getent passwd "$SERVICE_USER" >/dev/null 2>&1; then
+        note "creating system user ${SERVICE_USER}"
+        run_root useradd --system --user-group --home-dir "$DATA_ROOT" --shell /usr/sbin/nologin "$SERVICE_USER"
+    fi
+    TARGET_USER="$SERVICE_USER"
+    TARGET_GROUP="$(id -gn "$SERVICE_USER")" || die "could not determine the primary group for $SERVICE_USER"
+    if getent group fuse >/dev/null 2>&1; then
+        run_root usermod -aG fuse "$SERVICE_USER"
+    else
+        warn "fuse group does not exist; the service may not be able to access /dev/fuse"
+    fi
+}
+
+prepare_directories() {
+    if [ "$SETUP_SERVICE" -eq 1 ]; then
+        TARGET_USER="$SERVICE_USER"
+        if [ "$DRY_RUN" -eq 0 ]; then
+            TARGET_GROUP="$(id -gn "$SERVICE_USER")" || die "could not determine the primary group for $SERVICE_USER"
+        else
+            TARGET_GROUP="$SERVICE_USER"
+        fi
+    else
+        TARGET_USER="${SUDO_USER:-$(id -un)}"
+        TARGET_GROUP="$(id -gn "$TARGET_USER" 2>/dev/null || id -gn)"
+    fi
+    run_root install -d -o "$TARGET_USER" -g "$TARGET_GROUP" \
+        "$DATA_ROOT" "$WORKSPACE" "$STORE_PATH" \
+        "$DATA_ROOT/antares" "$DATA_ROOT/antares/upper" \
+        "$DATA_ROOT/antares/cl" "$DATA_ROOT/antares/mnt"
+    run_root install -d "$CONFDIR"
+}
+
+write_config() {
+    local config_tmp="${WORKDIR:-${TMPDIR:-/tmp}}/scorpio.toml"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        note "would write ${CONFDIR}/scorpio.toml with the supplied URLs and paths"
+        return 0
+    fi
+    umask 077
+    cat > "$config_tmp" <<EOF
+# Generated by ScorpioFS install.sh. Edit base_url/lfs_url when the backend changes.
+base_url = "$BASE_URL"
+lfs_url = "$LFS_URL"
+workspace = "$WORKSPACE"
+store_path = "$STORE_PATH"
+config_file = "$DATA_ROOT/config.toml"
+git_author = "$GIT_AUTHOR"
+git_email = "$GIT_EMAIL"
+log_level = "info"
+antares_upper_root = "$DATA_ROOT/antares/upper"
+antares_cl_root = "$DATA_ROOT/antares/cl"
+antares_mount_root = "$DATA_ROOT/antares/mnt"
+antares_state_file = "$DATA_ROOT/antares/state.toml"
+EOF
+    if [ -f "${CONFDIR}/scorpio.toml" ] && [ "$OVERWRITE_CONFIG" -ne 1 ]; then
+        warn "${CONFDIR}/scorpio.toml already exists; leaving it unchanged"
+        rm -f "$config_tmp"
+        return 0
+    fi
+    run_root install -m 0640 -o "$TARGET_USER" -g "$TARGET_GROUP" "$config_tmp" "${CONFDIR}/scorpio.toml"
+    rm -f "$config_tmp"
+}
+
+enable_user_allow_other() {
+    [ "$ENABLE_USER_ALLOW_OTHER" -eq 1 ] || { note "leaving /etc/fuse.conf unchanged"; return 0; }
+    if [ "$DRY_RUN" -eq 1 ]; then
+        run_root sh -c "grep -qE '^[[:space:]]*user_allow_other[[:space:]]*$' /etc/fuse.conf || printf '%s\\n' user_allow_other >> /etc/fuse.conf"
+        return 0
+    fi
+    if run_root grep -qE '^[[:space:]]*user_allow_other[[:space:]]*$' /etc/fuse.conf 2>/dev/null; then
+        note "/etc/fuse.conf already enables user_allow_other"
+    else
+        note "enabling user_allow_other in /etc/fuse.conf"
+        printf 'user_allow_other\n' | run_root tee -a /etc/fuse.conf >/dev/null
+    fi
+}
+
+install_systemd_service() {
+    [ "$SETUP_SERVICE" -eq 1 ] || return 0
+    if ! command -v systemctl >/dev/null 2>&1; then
+        warn "systemctl is unavailable; binaries and config were installed without a service"
         return 0
     fi
     if [ "$DRY_RUN" -eq 1 ]; then
-        printf '  [dry-run] write generic %s/scorpio.toml\n' "$CONFDIR"
+        note "would install /etc/systemd/system/scorpiofs.service and enable it"
         return 0
     fi
-    cat > "${CONFDIR}/scorpio.toml" <<'EOF'
-# Generated by install.sh. Set base_url/lfs_url to your mega server.
-base_url = "http://localhost:8000"
-lfs_url = "http://localhost:8000/lfs"
-workspace = "/var/lib/scorpiofs/mount"
-store_path = "/var/lib/scorpiofs/store"
-config_file = "/var/lib/scorpiofs/config.toml"
-git_author = "MEGA"
-git_email = "admin@mega.org"
-log_level = "info"
-antares_upper_root = "/var/lib/scorpiofs/antares/upper"
-antares_cl_root = "/var/lib/scorpiofs/antares/cl"
-antares_mount_root = "/var/lib/scorpiofs/antares/mnt"
-antares_state_file = "/var/lib/scorpiofs/antares/state.toml"
+    local unit_tmp="${WORKDIR}/scorpiofs.service"
+    local fuse_group_line=""
+    if getent group fuse >/dev/null 2>&1; then fuse_group_line="SupplementaryGroups=fuse"; fi
+    cat > "$unit_tmp" <<EOF
+[Unit]
+Description=ScorpioFS workspace daemon (FUSE mount + HTTP API)
+Documentation=https://github.com/${REPO}
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=simple
+User=${SERVICE_USER}
+Group=${TARGET_GROUP}
+${fuse_group_line}
+AmbientCapabilities=CAP_SYS_ADMIN
+CapabilityBoundingSet=CAP_SYS_ADMIN
+WorkingDirectory=${DATA_ROOT}
+ExecStart=${PREFIX}/bin/scorpio --config-path ${CONFDIR}/scorpio.toml serve --http-addr ${HTTP_ADDR}
+Restart=on-failure
+RestartSec=5s
+TimeoutStopSec=45
+KillMode=mixed
+LimitNOFILE=65536
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
 EOF
+    run_root install -m 0644 "$unit_tmp" /etc/systemd/system/scorpiofs.service
+    run_root systemctl daemon-reload
+    if ! run_root systemctl enable --now scorpiofs.service; then
+        warn "systemd unit installed but could not start; inspect: systemctl status scorpiofs"
+    fi
 }
 
 uninstall() {
-    note "removing binaries from ${PREFIX}/bin (config and data are kept)"
-    require_root
-    run rm -f "${PREFIX}/bin/scorpio" "${PREFIX}/bin/antares"
-    note "to remove config/data, delete ${CONFDIR} and /var/lib/scorpiofs manually"
+    require_privileges
+    if command -v systemctl >/dev/null 2>&1; then
+        run_root systemctl disable --now scorpiofs.service 2>/dev/null || true
+        run_root rm -f /etc/systemd/system/scorpiofs.service
+        run_root systemctl daemon-reload 2>/dev/null || true
+    fi
+    run_root rm -f "${PREFIX}/bin/scorpio" "${PREFIX}/bin/antares"
+    note "removed ScorpioFS binaries and service; kept ${CONFDIR} and ${DATA_ROOT}"
 }
 
 main() {
-    while [ "$#" -gt 0 ]; do
-        case "$1" in
-            --version) VERSION="${2:?--version needs a value}"; shift 2 ;;
-            --prefix)  PREFIX="${2:?--prefix needs a value}"; shift 2 ;;
-            --dry-run) DRY_RUN=1; shift ;;
-            --uninstall) DO_UNINSTALL=1; shift ;;
-            --no-deps) INSTALL_DEPS=0; shift ;;
-            --enable-user-allow-other) ENABLE_USER_ALLOW_OTHER=1; shift ;;
-            -h|--help) usage; exit 0 ;;
-            *) die "unknown option: $1 (see --help)" ;;
-        esac
-    done
-
-    if [ "$DRY_RUN" -eq 1 ]; then
-        note "dry-run: no changes will be made"
+    parse_args "$@"
+    if [ "$DO_UNINSTALL" -eq 1 ]; then uninstall; exit 0; fi
+    if [ "$INTERACTIVE" -eq 1 ] && [ ! -e /dev/tty ] && [ "$ASSUME_YES" -eq 0 ]; then
+        die "interactive input requires a terminal; use --non-interactive with --base-url and --lfs-url"
     fi
 
-    if [ "$DO_UNINSTALL" -eq 1 ]; then
-        uninstall
-        note "uninstall complete"
-        exit 0
-    fi
+    check_tools
+    resolve_version
+    normalize_version
+    configure_interactively
+    if [ -z "$BASE_URL" ]; then BASE_URL="http://localhost:8000"; fi
+    if [ -z "$LFS_URL" ]; then LFS_URL="$(normalize_url "$BASE_URL")/lfs"; fi
+    if [ -z "$WORKSPACE" ]; then WORKSPACE="$DATA_ROOT/mount"; fi
+    if [ -z "$STORE_PATH" ]; then STORE_PATH="$DATA_ROOT/store"; fi
+    validate_inputs
+    require_privileges
 
-    [ -n "$VERSION" ] || die "--version is required (e.g. --version v0.3.0); see --help"
-
-    if [ "$INSTALL_DEPS" -eq 1 ]; then
-        pkg_install
-    else
-        note "skipping system dependency installation (--no-deps)"
-    fi
-
+    note "installing ScorpioFS ${VERSION} for $(detect_target)"
+    pkg_install
+    check_fuse
     install_binaries
-    generate_config
-    maybe_enable_user_allow_other
+    ensure_service_account
+    prepare_directories
+    write_config
+    enable_user_allow_other
+    install_systemd_service
 
-    note "done. Edit ${CONFDIR}/scorpio.toml (set base_url/lfs_url), then run:"
-    note "  scorpio --config-path ${CONFDIR}/scorpio.toml doctor"
-    note "  scorpio --config-path ${CONFDIR}/scorpio.toml serve"
+    note "installation complete"
+    note "config: ${CONFDIR}/scorpio.toml"
+    note "check:  ${PREFIX}/bin/scorpio --config-path ${CONFDIR}/scorpio.toml doctor"
+    note "health: curl http://127.0.0.1:${HTTP_ADDR##*:}/health"
+    if [ "$SETUP_SERVICE" -eq 1 ]; then
+        note "logs:   journalctl -u scorpiofs -f"
+    else
+        note "run:    ${PREFIX}/bin/scorpio --config-path ${CONFDIR}/scorpio.toml serve --http-addr ${HTTP_ADDR}"
+    fi
 }
 
 main "$@"
-

--- a/install.sh
+++ b/install.sh
@@ -137,6 +137,14 @@ run_root() {
     fi
 }
 
+run_readonly() {
+    if [ -n "$SUDO_BIN" ]; then
+        "$SUDO_BIN" "$@"
+    else
+        "$@"
+    fi
+}
+
 require_privileges() {
     [ "$DRY_RUN" -eq 1 ] && return 0
     if [ "$(id -u)" -eq 0 ]; then
@@ -318,9 +326,13 @@ validate_data_paths() {
         [ ! -L "$runtime_file" ] || die "runtime state file must not be a symbolic link: $runtime_file"
     done
     [ ! -L "$CONFDIR/scorpio.toml" ] || die "config file must not be a symbolic link: $CONFDIR/scorpio.toml"
-    if [ -d "$DATA_ROOT" ] && [ "$EXISTING_CONFIG" -eq 0 ] && \
-        [ -n "$(find "$DATA_ROOT" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
-        die "refusing to change ownership of a nonempty data-root without an existing ScorpioFS config: $DATA_ROOT"
+    if [ -d "$DATA_ROOT" ] && [ "$EXISTING_CONFIG" -eq 0 ]; then
+        local data_root_entry
+        if ! data_root_entry="$(find "$DATA_ROOT" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)"; then
+            die "could not inspect data-root; refusing to change ownership without verifying it is empty: $DATA_ROOT"
+        fi
+        [ -z "$data_root_entry" ] || \
+            die "refusing to change ownership of a nonempty data-root without an existing ScorpioFS config: $DATA_ROOT"
     fi
 }
 
@@ -1050,9 +1062,7 @@ recover_stale_runtime_mounts() {
         # Mount health is a read-only check, so dry-runs must execute it to
         # preserve the same stale-versus-active decision as a real install.
         local probe_succeeded=0
-        if [ "$DRY_RUN" -eq 1 ]; then
-            if "${probe[@]}"; then probe_succeeded=1; fi
-        elif run_root "${probe[@]}"; then
+        if run_readonly "${probe[@]}"; then
             probe_succeeded=1
         fi
         if [ "$probe_succeeded" -eq 1 ] && [ "$detach_managed_mounts" -ne 1 ]; then
@@ -1210,6 +1220,8 @@ install_systemd_service() {
     fi
     local unit_tmp="${WORKDIR}/scorpiofs.service"
     local fuse_group_line=""
+    local escaped_antares_mount
+    escaped_antares_mount="$(toml_escape "$ANTARES_MOUNT_ROOT")"
     if getent group fuse >/dev/null 2>&1; then fuse_group_line="SupplementaryGroups=fuse"; fi
     cat > "$unit_tmp" <<EOF
 [Unit]
@@ -1229,7 +1241,7 @@ AmbientCapabilities=CAP_SYS_ADMIN
 CapabilityBoundingSet=CAP_SYS_ADMIN
 WorkingDirectory=${DATA_ROOT}
 ExecStart=${PREFIX}/bin/scorpio --config-path ${CONFDIR}/scorpio.toml serve --http-addr ${HTTP_ADDR}
-ExecStopPost=-/bin/sh -c 'for m in \$(findmnt -rno TARGET --submounts ${ANTARES_MOUNT_ROOT} 2>/dev/null | sort -r); do fusermount3 -u -z "\$m"; done'
+ExecStopPost=-/bin/sh -c 'root="${escaped_antares_mount}"; findmnt -rno TARGET 2>/dev/null | sort -r | while IFS= read -r m; do case "\$m" in "\$root"|"\$root"/*) fusermount3 -u -z "\$m";; esac; done'
 ExecStopPost=-/usr/bin/fusermount3 -u -z ${WORKSPACE}
 Restart=on-failure
 RestartSec=5s

--- a/install.sh
+++ b/install.sh
@@ -358,12 +358,24 @@ paths_overlap() {
     return 1
 }
 
+path_is_at_or_below() {
+    local path="$1" parent="$2"
+    case "$path" in "$parent"|"$parent"/*) return 0 ;; esac
+    return 1
+}
+
 validate_runtime_path_separation() {
-    local mount_field mount_path persistent_field persistent_path i j
+    local mount_field mount_path persistent_field persistent_path installer_field installer_path i j
     local -a mount_fields=(workspace antares-mount-root)
     local -a mount_paths=("$WORKSPACE" "$ANTARES_MOUNT_ROOT")
     local -a persistent_fields=(store-path config-file antares-upper-root antares-cl-root antares-state-file)
     local -a persistent_paths=("$STORE_PATH" "$CONFIG_FILE" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT" "$ANTARES_STATE_FILE")
+    local -a installer_fields=(scorpio-binary antares-binary main-config)
+    local -a installer_paths=(
+        "$(realpath -m -- "${PREFIX}/bin/scorpio")"
+        "$(realpath -m -- "${PREFIX}/bin/antares")"
+        "$(realpath -m -- "${CONFDIR}/scorpio.toml")"
+    )
     for ((i = 0; i < ${#mount_fields[@]}; i++)); do
         mount_field="${mount_fields[$i]}"
         mount_path="${mount_paths[$i]}"
@@ -372,6 +384,13 @@ validate_runtime_path_separation() {
             persistent_path="${persistent_paths[$j]}"
             if paths_overlap "$mount_path" "$persistent_path"; then
                 die "$mount_field must not overlap $persistent_field: $mount_path and $persistent_path"
+            fi
+        done
+        for ((j = 0; j < ${#installer_fields[@]}; j++)); do
+            installer_field="${installer_fields[$j]}"
+            installer_path="${installer_paths[$j]}"
+            if path_is_at_or_below "$installer_path" "$mount_path"; then
+                die "$mount_field must not contain $installer_field: $installer_path"
             fi
         done
     done
@@ -804,8 +823,8 @@ validate_inputs() {
     validate_bind "$HTTP_ADDR"
     is_loopback_host "$BIND_HOST" || [ "$ALLOW_PUBLIC_API" -eq 1 ] || \
         die "refusing non-loopback HTTP bind without --allow-public-api"
-    [[ "$GIT_AUTHOR" != *$'\n'* && "$GIT_AUTHOR" != *$'\r'* ]] || die "git author contains a newline"
-    [[ "$GIT_EMAIL" != *$'\n'* && "$GIT_EMAIL" != *$'\r'* ]] || die "git email contains a newline"
+    validate_toml_text "git author" "$GIT_AUTHOR"
+    validate_toml_text "git email" "$GIT_EMAIL"
     [ -n "$GIT_AUTHOR" ] || die "git author must not be empty"
     [ -n "$GIT_EMAIL" ] || die "git email must not be empty"
     [[ "$SERVICE_USER" =~ ^[a-z_][a-z0-9_-]{0,31}$ ]] || die "invalid service user: $SERVICE_USER"
@@ -959,6 +978,14 @@ toml_escape() {
     value="${value//\"/\\\"}"
     value="${value//$'\t'/\\t}"
     printf '%s' "$value"
+}
+
+validate_toml_text() {
+    local field="$1" value_without_tabs="${2//$'\t'/}"
+    local LC_ALL=C
+    if [[ "$value_without_tabs" =~ [[:cntrl:]] ]]; then
+        die "$field must not contain control characters other than tab"
+    fi
 }
 
 write_config() {

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,10 @@ STORE_PATH_SET=0
 EXISTING_CONFIG=0
 RETAIN_CONFIG=0
 EXISTING_SERVICE_USER=""
-SERVICE_STOPPED_FOR_MIGRATION=0
+SERVICE_STOPPED_FOR_UPGRADE=0
+PREVIOUS_WORKSPACE=""
+PREVIOUS_ANTARES_MOUNT_ROOT=""
+EXTRACTED_RELEASE=""
 REQUESTED_WORKSPACE=""
 REQUESTED_STORE_PATH=""
 WORKDIR=""
@@ -538,6 +541,8 @@ prepare_effective_runtime_paths() {
         if [ "$DATA_ROOT_SET" -eq 0 ]; then infer_data_root; fi
         resolve_relative_runtime_paths
         validate_runtime_paths
+        PREVIOUS_WORKSPACE="$WORKSPACE"
+        PREVIOUS_ANTARES_MOUNT_ROOT="$ANTARES_MOUNT_ROOT"
     fi
 
     if [ "$RETAIN_CONFIG" -eq 1 ]; then
@@ -566,16 +571,15 @@ detect_existing_service_user() {
     EXISTING_SERVICE_USER="$candidate"
 }
 
-stop_active_service_for_user_migration() {
+stop_active_service_for_upgrade() {
     [ "$SETUP_SERVICE" -eq 1 ] || return 0
     [ -n "$EXISTING_SERVICE_USER" ] || return 0
-    [ "$EXISTING_SERVICE_USER" != "$SERVICE_USER" ] || return 0
     if run_root systemctl is-active --quiet scorpiofs.service; then
-        note "stopping the active service before migrating data from $EXISTING_SERVICE_USER to $SERVICE_USER"
+        note "stopping the active service before replacing its binary, config, or unit"
         if ! run_root systemctl stop scorpiofs.service; then
-            die "could not stop scorpiofs.service before changing its service user"
+            die "could not stop scorpiofs.service before upgrading it"
         fi
-        SERVICE_STOPPED_FOR_MIGRATION=1
+        SERVICE_STOPPED_FOR_UPGRADE=1
     fi
 }
 
@@ -833,7 +837,7 @@ validate_inputs() {
     [[ "$SERVICE_USER" =~ ^[a-z_][a-z0-9_-]{0,31}$ ]] || die "invalid service user: $SERVICE_USER"
 }
 
-install_binaries() {
+prepare_release_binaries() {
     local target tarball base url sumurl extracted installed_binary
     target="$(detect_target)"
     tarball="scorpiofs-${VERSION}-${target}.tar.gz"
@@ -871,7 +875,7 @@ install_binaries() {
         die "sha256sum or shasum is required for checksum verification"
     fi
 
-    note "extracting and installing to ${PREFIX}/bin"
+    note "extracting and checking release binaries"
     tar -xzf "${WORKDIR}/${tarball}" -C "$WORKDIR"
     extracted="${WORKDIR}/scorpiofs-${VERSION}-${target}"
     if [ ! -x "${extracted}/scorpio" ] || [ ! -x "${extracted}/antares" ]; then
@@ -885,9 +889,18 @@ install_binaries() {
         die "downloaded antares cannot run on this host: ${smoke_output}. Install a release built for this Linux distribution"
     fi
     prepare_effective_runtime_paths "${extracted}/scorpio"
+    EXTRACTED_RELEASE="$extracted"
+}
+
+install_release_binaries() {
+    if [ "$DRY_RUN" -eq 1 ]; then
+        return 0
+    fi
+    [ -n "$EXTRACTED_RELEASE" ] || die "internal error: release binaries were not prepared"
+    note "installing release binaries to ${PREFIX}/bin"
     run_root install -d "${PREFIX}/bin"
-    run_root install -m 0755 "${extracted}/scorpio" "${PREFIX}/bin/scorpio"
-    run_root install -m 0755 "${extracted}/antares" "${PREFIX}/bin/antares"
+    run_root install -m 0755 "${EXTRACTED_RELEASE}/scorpio" "${PREFIX}/bin/scorpio"
+    run_root install -m 0755 "${EXTRACTED_RELEASE}/antares" "${PREFIX}/bin/antares"
 }
 
 ensure_service_account() {
@@ -941,36 +954,69 @@ prepare_directories() {
     run_root install -d "$CONFDIR"
 }
 
-path_is_mount_target() {
-    local path="$1" mount_target mount_targets
-    mount_targets="$(findmnt --noheadings --raw --output TARGET)" || \
+find_mount_fstype() {
+    local path="$1" mount_target mount_fstype mount_entries
+    MOUNT_FSTYPE=""
+    mount_entries="$(findmnt --noheadings --raw --output TARGET,FSTYPE)" || \
         die "could not inspect FUSE mount roots"
-    while IFS= read -r mount_target; do
-        [ "$mount_target" = "$path" ] && return 0
-    done <<<"$mount_targets"
+    while read -r mount_target mount_fstype; do
+        if [ "$mount_target" = "$path" ]; then
+            MOUNT_FSTYPE="$mount_fstype"
+            return 0
+        fi
+    done <<<"$mount_entries"
     return 1
 }
 
+path_is_mount_target() {
+    find_mount_fstype "$1"
+}
+
 recover_stale_runtime_mounts() {
-    local mount_field mount_root i
-    local -a mount_fields=(workspace antares-mount-root)
-    local -a mount_roots=("$WORKSPACE" "$ANTARES_MOUNT_ROOT")
+    local detach_managed_mounts="${1:-0}" mount_field mount_root i j duplicate
+    local -a candidate_fields=(previous-workspace previous-antares-mount-root workspace antares-mount-root)
+    local -a candidate_roots=("$PREVIOUS_WORKSPACE" "$PREVIOUS_ANTARES_MOUNT_ROOT" "$WORKSPACE" "$ANTARES_MOUNT_ROOT")
+    local -a mount_fields=() mount_roots=()
     local -a probe
-    for ((i = 0; i < ${#mount_fields[@]}; i++)); do
+    for ((i = 0; i < ${#candidate_fields[@]}; i++)); do
+        mount_root="${candidate_roots[$i]}"
+        [ -n "$mount_root" ] || continue
+        duplicate=0
+        for ((j = 0; j < ${#mount_roots[@]}; j++)); do
+            if [ "${mount_roots[$j]}" = "$mount_root" ]; then duplicate=1; break; fi
+        done
+        [ "$duplicate" -eq 1 ] && continue
+        mount_fields+=("${candidate_fields[$i]}")
+        mount_roots+=("$mount_root")
+    done
+    for ((i = 0; i < ${#mount_roots[@]}; i++)); do
         mount_field="${mount_fields[$i]}"
         mount_root="${mount_roots[$i]}"
-        path_is_mount_target "$mount_root" || continue
+        find_mount_fstype "$mount_root" || continue
+        case "$MOUNT_FSTYPE" in
+            fuse|fuse.*) ;;
+            *)
+                die "$mount_field is mounted with non-FUSE filesystem type ${MOUNT_FSTYPE:-unknown} at $mount_root; unmount it manually and retry"
+                ;;
+        esac
         # $1 is intentionally expanded by the probe shell.
         # shellcheck disable=SC2016
         probe=(timeout 15 bash -c 'stat -L -- "$1" >/dev/null 2>&1' bash "$mount_root")
         if [ -n "$EXISTING_SERVICE_USER" ]; then
             probe=(runuser -u "$EXISTING_SERVICE_USER" -- "${probe[@]}")
         fi
-        if run_root "${probe[@]}"; then
+        if run_root "${probe[@]}" && [ "$detach_managed_mounts" -ne 1 ]; then
+            if [ "$SETUP_SERVICE" -eq 1 ] && [ -z "$EXISTING_SERVICE_USER" ]; then
+                die "$mount_field is actively mounted at $mount_root by an unmanaged process; stop the ScorpioFS daemon, unmount this path, and retry"
+            fi
             note "$mount_field is actively mounted; leaving the mount root unchanged during directory preparation"
             continue
         fi
-        warn "detaching inaccessible FUSE mount at $mount_root before installation"
+        if [ "$detach_managed_mounts" -eq 1 ]; then
+            warn "detaching FUSE mount left by the stopped service at $mount_root"
+        else
+            warn "detaching inaccessible FUSE mount at $mount_root before installation"
+        fi
         if command -v fusermount3 >/dev/null 2>&1; then
             run_root fusermount3 -u -z "$mount_root" || \
                 run_root umount -l "$mount_root" || \
@@ -1151,8 +1197,8 @@ EOF
         die "could not enable scorpiofs.service; inspect: systemctl status scorpiofs"
     fi
     local service_action="start"
-    if [ "$SERVICE_STOPPED_FOR_MIGRATION" -eq 1 ]; then
-        note "starting ScorpioFS with the new service user"
+    if [ "$SERVICE_STOPPED_FOR_UPGRADE" -eq 1 ]; then
+        note "starting ScorpioFS after the managed upgrade"
     elif run_root systemctl is-active --quiet scorpiofs.service; then
         service_action="restart"
         note "restarting the active ScorpioFS service to load the new binary and config"
@@ -1197,11 +1243,13 @@ main() {
     pkg_install
     check_runtime_tools
     check_fuse
-    install_binaries
+    prepare_release_binaries
+    recover_stale_runtime_mounts
     validate_runtime_migration_mounts
     ensure_service_account
-    stop_active_service_for_user_migration
-    recover_stale_runtime_mounts
+    stop_active_service_for_upgrade
+    recover_stale_runtime_mounts "$SERVICE_STOPPED_FOR_UPGRADE"
+    install_release_binaries
     prepare_directories
     reconcile_runtime_directories
     reconcile_runtime_files

--- a/install.sh
+++ b/install.sh
@@ -117,7 +117,7 @@ Options:
   --uninstall               Stop/remove binaries and the systemd unit; keep data.
   --no-deps                 Skip system package installation.
   --enable-user-allow-other Enable user_allow_other in /etc/fuse.conf.
-  --no-user-allow-other     Do not change /etc/fuse.conf.
+  --no-user-allow-other     Do not change /etc/fuse.conf (it must already enable user_allow_other).
   -h, --help                Show this help message.
 
 Examples:
@@ -1263,6 +1263,15 @@ validate_installed_config() {
     fi
 }
 
+validate_user_allow_other() {
+    [ "$ENABLE_USER_ALLOW_OTHER" -eq 1 ] && return 0
+    if run_root grep -qE '^[[:space:]]*user_allow_other[[:space:]]*$' /etc/fuse.conf 2>/dev/null; then
+        note "using the existing user_allow_other setting in /etc/fuse.conf"
+        return 0
+    fi
+    die "user_allow_other is required because ScorpioFS uses allow_other FUSE mounts; rerun with --enable-user-allow-other"
+}
+
 enable_user_allow_other() {
     [ "$ENABLE_USER_ALLOW_OTHER" -eq 1 ] || { note "leaving /etc/fuse.conf unchanged"; return 0; }
     if [ "$DRY_RUN" -eq 1 ]; then
@@ -1345,12 +1354,12 @@ wait_for_service_health() {
             die "scorpiofs.service is not active after starting; inspect: systemctl status scorpiofs"
         fi
         if [ "$DOWNLOADER" = "curl" ]; then
-            if curl -fsS --connect-timeout 2 --max-time 5 "$endpoint" >/dev/null 2>&1; then
+            if curl -fsS --noproxy '*' --connect-timeout 2 --max-time 5 "$endpoint" >/dev/null 2>&1; then
                 SERVICE_HEALTH_CONFIRMED=1
                 note "scorpiofs.service is healthy at ${endpoint}"
                 return 0
             fi
-        elif wget -q --timeout=2 --tries=1 -O /dev/null "$endpoint"; then
+        elif wget -q --no-proxy --timeout=2 --tries=1 -O /dev/null "$endpoint"; then
             SERVICE_HEALTH_CONFIRMED=1
             note "scorpiofs.service is healthy at ${endpoint}"
             return 0
@@ -1390,6 +1399,7 @@ main() {
     set_generated_runtime_paths
     validate_inputs
     require_privileges
+    validate_user_allow_other
 
     note "installing ScorpioFS ${VERSION} for $(detect_target)"
     pkg_install

--- a/install.sh
+++ b/install.sh
@@ -42,10 +42,14 @@ ALLOW_PUBLIC_API=0
 OVERWRITE_CONFIG=0
 SERVICE_CHOICE_SET=0
 FUSE_CHOICE_SET=0
+CONFIG_CHOICE_SET=0
 WORKDIR=""
 SUDO_BIN=""
 TARGET_USER=""
 TARGET_GROUP=""
+TTY_FD=""
+BIND_HOST=""
+BIND_PORT=""
 
 cleanup() {
     if [ -n "${WORKDIR:-}" ] && [ -d "$WORKDIR" ]; then
@@ -69,12 +73,13 @@ Options:
   --data-root <dir>         Runtime/data root (default: /var/lib/scorpiofs).
   --base-url <url>          Mega/monorepo service URL.
   --lfs-url <url>           Git LFS endpoint URL.
-  --workspace <dir>         FUSE workspace directory.
-  --store-path <dir>        Local cache/store directory.
-  --http-addr <ip:port>     HTTP API bind address (default: 127.0.0.1:2725).
+  --workspace <dir>         FUSE workspace inside data-root.
+  --store-path <dir>        Local cache/store inside data-root.
+  --http-addr <socket>      IPv4:port or [IPv6]:port (default: 127.0.0.1:2725).
   --allow-public-api        Permit a non-loopback HTTP bind (use a firewall/auth proxy).
   --no-service              Do not create or start a systemd service.
   --non-interactive         Use arguments/environment without prompting.
+  --overwrite-config        Replace an existing scorpio.toml during an upgrade.
   --yes                     Accept safe defaults in interactive mode.
   --dry-run                 Print actions without changing the system.
   --uninstall               Stop/remove binaries and the systemd unit; keep data.
@@ -86,7 +91,7 @@ Options:
 Examples:
   sudo bash install.sh
   bash install.sh --base-url https://mega.example.com --lfs-url https://mega.example.com/lfs
-  bash install.sh --version v0.4.0 --non-interactive --dry-run
+  bash install.sh --version v0.4.0 --non-interactive --overwrite-config --dry-run
 
 The HTTP API has no authentication. The installer therefore defaults to
 127.0.0.1 and asks for explicit confirmation before accepting a public bind.
@@ -123,11 +128,8 @@ require_privileges() {
 }
 
 read_tty() {
-    if [ -r /dev/tty ]; then
-        IFS= read -r REPLY </dev/tty || REPLY=""
-    else
-        IFS= read -r REPLY || REPLY=""
-    fi
+    [ -n "$TTY_FD" ] || die "interactive input is unavailable; use --non-interactive"
+    IFS= read -r REPLY <&"$TTY_FD" || die "could not read interactive input from /dev/tty"
 }
 
 prompt_value() {
@@ -136,7 +138,7 @@ prompt_value() {
         printf -v "$variable" '%s' "$default"
         return 0
     fi
-    printf '%s [%s]: ' "$label" "$default" >/dev/tty 2>/dev/null || printf '%s [%s]: ' "$label" "$default"
+    printf '%s [%s]: ' "$label" "$default" >&"$TTY_FD"
     read_tty
     if [ -z "$REPLY" ]; then REPLY="$default"; fi
     printf -v "$variable" '%s' "$REPLY"
@@ -152,7 +154,7 @@ prompt_yes_no() {
         return 0
     fi
     while :; do
-        printf '%s [%s]: ' "$label" "$default" >/dev/tty 2>/dev/null || printf '%s [%s]: ' "$label" "$default"
+        printf '%s [%s]: ' "$label" "$default" >&"$TTY_FD"
         read_tty
         answer="${REPLY:-$default}"
         case "$answer" in
@@ -170,9 +172,80 @@ validate_url() {
         *) die "$field must start with http:// or https:// (got: $value)" ;;
     esac
     [[ "$value" != *[[:space:]]* ]] || die "$field must not contain whitespace"
-    [[ "$value" != *'"'* ]] || die "$field must not contain a double quote"
-    [[ "$value" != *"'"* ]] || die "$field must not contain a single quote"
-    [[ "$value" != *'`'* && "$value" != *'\\'* ]] || die "$field contains an unsafe character"
+    [[ "$value" != *'"'* && "$value" != *"'"* ]] || die "$field must not contain quotes"
+    [[ "$value" != *'`'* && "$value" != *\\* ]] || die "$field contains an unsafe character"
+    [[ "$value" != *'?'* && "$value" != *'#'* ]] || die "$field must not contain a query or fragment"
+
+    local remainder authority host port=""
+    remainder="${value#*://}"
+    authority="${remainder%%/*}"
+    [ -n "$authority" ] || die "$field must include a host"
+    [[ "$authority" != *'@'* ]] || die "$field must not contain credentials"
+
+    if [[ "$authority" =~ ^\[([^]]+)\](:([0-9]+))?$ ]]; then
+        host="${BASH_REMATCH[1]}"
+        port="${BASH_REMATCH[3]:-}"
+        validate_ipv6 "$field host" "$host"
+    else
+        host="$authority"
+        if [[ "$authority" == *:* ]]; then
+            host="${authority%:*}"
+            port="${authority##*:}"
+            [[ "$host" != *:* ]] || die "$field has an IPv6 host without brackets"
+        fi
+        validate_url_host "$field host" "$host"
+    fi
+    [ -z "$port" ] || validate_port "$field port" "$port"
+}
+
+validate_port() {
+    local field="$1" value="$2"
+    [[ "$value" =~ ^[0-9]{1,5}$ ]] || die "$field must be a numeric port"
+    (( 10#$value >= 1 && 10#$value <= 65535 )) || die "$field must be between 1 and 65535"
+}
+
+validate_ipv4() {
+    local field="$1" value="$2" a b c d extra octet
+    IFS=. read -r a b c d extra <<<"$value"
+    if [ -n "${extra:-}" ] || [ -z "${a:-}" ] || [ -z "${b:-}" ] || \
+        [ -z "${c:-}" ] || [ -z "${d:-}" ]; then
+        die "$field is not a valid IPv4 address"
+    fi
+    for octet in "$a" "$b" "$c" "$d"; do
+        if ! [[ "$octet" =~ ^[0-9]{1,3}$ ]] || (( 10#$octet > 255 )); then
+            die "$field is not a valid IPv4 address"
+        fi
+    done
+}
+
+validate_ipv6() {
+    local field="$1" value="$2"
+    [[ "$value" == *:* && "$value" =~ ^[0-9A-Fa-f:.]+$ ]] || \
+        die "$field is not a valid IPv6 address"
+    command -v getent >/dev/null 2>&1 || die "getent is required to validate IPv6 addresses"
+    getent ahostsv6 "$value" >/dev/null 2>&1 || die "$field is not a valid IPv6 address"
+}
+
+validate_url_host() {
+    local field="$1" value="$2" label
+    local -a labels
+    [ -n "$value" ] || die "$field must not be empty"
+    if [[ "$value" =~ ^[0-9.]+$ ]]; then
+        validate_ipv4 "$field" "$value"
+        return 0
+    fi
+    [[ "$value" != *'..'* ]] || die "$field is not a valid hostname"
+    IFS=. read -ra labels <<<"$value"
+    for label in "${labels[@]}"; do
+        [[ "$label" =~ ^[A-Za-z0-9]([A-Za-z0-9_-]{0,61}[A-Za-z0-9])?$ ]] || \
+            die "$field is not a valid hostname"
+    done
+}
+
+normalize_path() {
+    local value="$1"
+    while [ "$value" != "/" ] && [ "${value%/}" != "$value" ]; do value="${value%/}"; done
+    printf '%s' "$value"
 }
 
 validate_path() {
@@ -181,18 +254,70 @@ validate_path() {
     [[ "$value" == /* ]] || die "$field must be an absolute path: $value"
     [[ "$value" != *[[:space:]]* ]] || die "$field must not contain whitespace"
     [[ "$value" != *$'\n'* && "$value" != *$'\r'* ]] || die "$field must not contain a newline"
-    [[ "$value" != *'"'* && "$value" != *'`'* && "$value" != *'$'* && "$value" != *'\\'* ]] || die "$field contains an unsafe shell character"
+    [[ "$value" != *'"'* && "$value" != *"'"* && "$value" != *'`'* && \
+        "$value" != *'$'* && "$value" != *\\* && "$value" != *'%'* ]] || \
+        die "$field contains a character unsafe for shell or systemd use"
+    [[ "$value" != *'//'* ]] || die "$field must not contain repeated slashes"
+    case "/${value#/}/" in
+        *'/../'*|*'/./'*) die "$field must not contain . or .. path components" ;;
+    esac
+    [ ! -L "$value" ] || die "$field must not be a symbolic link: $value"
+}
+
+validate_data_paths() {
+    case "$DATA_ROOT" in
+        /|/bin|/boot|/dev|/etc|/home|/lib|/lib64|/media|/mnt|/opt|/proc|/root|/run|/sbin|/srv|/sys|/tmp|/usr|/usr/local|/var|/var/lib|/var/log)
+            die "data-root is too broad and must be a dedicated ScorpioFS directory: $DATA_ROOT"
+            ;;
+    esac
+    case "$WORKSPACE" in
+        "$DATA_ROOT"/*) ;;
+        *) die "workspace must be inside data-root ($DATA_ROOT): $WORKSPACE" ;;
+    esac
+    case "$STORE_PATH" in
+        "$DATA_ROOT"/*) ;;
+        *) die "store-path must be inside data-root ($DATA_ROOT): $STORE_PATH" ;;
+    esac
 }
 
 validate_bind() {
-    local value="$1"
-    [[ "$value" =~ ^(127\.0\.0\.1|0\.0\.0\.0|::1|\[::1\]):[0-9]{1,5}$ ]] || \
-        die "--http-addr must be an IPv4/IPv6 loopback or wildcard address such as 127.0.0.1:2725"
+    local value="$1" host port
+    if [[ "$value" =~ ^\[([^]]+)\]:([0-9]+)$ ]]; then
+        host="${BASH_REMATCH[1]}"
+        port="${BASH_REMATCH[2]}"
+        validate_ipv6 "--http-addr" "$host"
+    elif [[ "$value" =~ ^([^:]+):([0-9]+)$ ]]; then
+        host="${BASH_REMATCH[1]}"
+        port="${BASH_REMATCH[2]}"
+        validate_ipv4 "--http-addr" "$host"
+    else
+        die "--http-addr must be IPv4:port or [IPv6]:port"
+    fi
+    validate_port "--http-addr" "$port"
+    BIND_HOST="$host"
+    BIND_PORT="$port"
+}
+
+is_loopback_host() {
+    [[ "$1" == 127.* || "$1" == "::1" ]]
+}
+
+health_endpoint() {
+    local host="$BIND_HOST"
+    case "$host" in
+        0.0.0.0) host="127.0.0.1" ;;
+        ::) host="[::1]" ;;
+        *:*) host="[$host]" ;;
+    esac
+    printf 'http://%s:%s/health' "$host" "$BIND_PORT"
 }
 
 normalize_url() {
     local value="$1"
-    while [ "${value%/}" != "$value" ]; do value="${value%/}"; done
+    while [ "${value%/}" != "$value" ]; do
+        case "$value" in http://|https://) break ;; esac
+        value="${value%/}"
+    done
     printf '%s' "$value"
 }
 
@@ -212,6 +337,7 @@ parse_args() {
             --allow-public-api) ALLOW_PUBLIC_API=1; shift ;;
             --no-service) SETUP_SERVICE=0; SERVICE_CHOICE_SET=1; shift ;;
             --non-interactive) INTERACTIVE=0; shift ;;
+            --overwrite-config) OVERWRITE_CONFIG=1; CONFIG_CHOICE_SET=1; shift ;;
             --yes) ASSUME_YES=1; shift ;;
             --dry-run) DRY_RUN=1; shift ;;
             --uninstall) DO_UNINSTALL=1; INTERACTIVE=0; shift ;;
@@ -222,6 +348,22 @@ parse_args() {
             *) die "unknown option: $1 (see --help)" ;;
         esac
     done
+}
+
+apply_environment_options() {
+    case "${SCORPIO_OVERWRITE_CONFIG:-}" in
+        ""|0|false|FALSE|no|NO) ;;
+        1|true|TRUE|yes|YES) OVERWRITE_CONFIG=1; CONFIG_CHOICE_SET=1 ;;
+        *) die "SCORPIO_OVERWRITE_CONFIG must be 1/0, true/false, or yes/no" ;;
+    esac
+}
+
+open_interactive_tty() {
+    [ "$INTERACTIVE" -eq 1 ] && [ "$ASSUME_YES" -eq 0 ] || return 0
+    if ! { exec 3<>/dev/tty; } 2>/dev/null; then
+        die "interactive input requires a controlling terminal; use --non-interactive with --base-url and --lfs-url"
+    fi
+    TTY_FD=3
 }
 
 detect_target() {
@@ -315,23 +457,26 @@ configure_interactively() {
     if [ "$SETUP_SERVICE" -eq 1 ]; then
         prompt_value SERVICE_USER "systemd service user" "$SERVICE_USER"
     fi
-    if [ -f "${CONFDIR}/scorpio.toml" ]; then
+    if [ -f "${CONFDIR}/scorpio.toml" ] && [ "$CONFIG_CHOICE_SET" -eq 0 ]; then
         prompt_yes_no OVERWRITE_CONFIG "Overwrite existing ${CONFDIR}/scorpio.toml" "n"
     fi
 
-    case "$HTTP_ADDR" in
-        127.0.0.1:*|::1:*|\[::1\]:*) ;;
-        *)
-            warn "${HTTP_ADDR} is not loopback. ScorpioFS has no HTTP authentication."
-            prompt_yes_no PUBLIC_API_OK "Continue with an externally reachable API only behind a firewall/auth proxy" "n"
-            if [ "$PUBLIC_API_OK" -eq 1 ]; then ALLOW_PUBLIC_API=1; else HTTP_ADDR="127.0.0.1:2725"; fi
-            ;;
-    esac
+    validate_bind "$HTTP_ADDR"
+    if ! is_loopback_host "$BIND_HOST"; then
+        warn "${HTTP_ADDR} is not loopback. ScorpioFS has no HTTP authentication."
+        prompt_yes_no PUBLIC_API_OK "Continue with an externally reachable API only behind a firewall/auth proxy" "n"
+        if [ "$PUBLIC_API_OK" -eq 1 ]; then ALLOW_PUBLIC_API=1; else HTTP_ADDR="127.0.0.1:2725"; fi
+    fi
 }
 
 validate_inputs() {
     BASE_URL="$(normalize_url "$BASE_URL")"
     LFS_URL="$(normalize_url "$LFS_URL")"
+    PREFIX="$(normalize_path "$PREFIX")"
+    CONFDIR="$(normalize_path "$CONFDIR")"
+    DATA_ROOT="$(normalize_path "$DATA_ROOT")"
+    WORKSPACE="$(normalize_path "$WORKSPACE")"
+    STORE_PATH="$(normalize_path "$STORE_PATH")"
     validate_url base_url "$BASE_URL"
     validate_url lfs_url "$LFS_URL"
     validate_url release-base-url "$RELEASE_BASE_URL"
@@ -340,13 +485,14 @@ validate_inputs() {
     validate_path data-root "$DATA_ROOT"
     validate_path workspace "$WORKSPACE"
     validate_path store-path "$STORE_PATH"
+    validate_data_paths
     validate_bind "$HTTP_ADDR"
-    case "$HTTP_ADDR" in
-        127.0.0.1:*|::1:*|\[::1\]:*) ;;
-        *) [ "$ALLOW_PUBLIC_API" -eq 1 ] || die "refusing non-loopback HTTP bind without --allow-public-api" ;;
-    esac
-    [[ "$GIT_AUTHOR" != *$'\n'* && "$GIT_AUTHOR" != *'"'* ]] || die "git author contains an unsafe character"
-    [[ "$GIT_EMAIL" != *$'\n'* && "$GIT_EMAIL" != *'"'* ]] || die "git email contains an unsafe character"
+    is_loopback_host "$BIND_HOST" || [ "$ALLOW_PUBLIC_API" -eq 1 ] || \
+        die "refusing non-loopback HTTP bind without --allow-public-api"
+    [[ "$GIT_AUTHOR" != *$'\n'* && "$GIT_AUTHOR" != *$'\r'* ]] || die "git author contains a newline"
+    [[ "$GIT_EMAIL" != *$'\n'* && "$GIT_EMAIL" != *$'\r'* ]] || die "git email contains a newline"
+    [ -n "$GIT_AUTHOR" ] || die "git author must not be empty"
+    [ -n "$GIT_EMAIL" ] || die "git email must not be empty"
     [[ "$SERVICE_USER" =~ ^[a-z_][a-z0-9_-]{0,31}$ ]] || die "invalid service user: $SERVICE_USER"
 }
 
@@ -384,7 +530,9 @@ install_binaries() {
     note "extracting and installing to ${PREFIX}/bin"
     tar -xzf "${WORKDIR}/${tarball}" -C "$WORKDIR"
     extracted="${WORKDIR}/scorpiofs-${VERSION}-${target}"
-    [ -x "${extracted}/scorpio" ] && [ -x "${extracted}/antares" ] || die "release archive has an unexpected layout"
+    if [ ! -x "${extracted}/scorpio" ] || [ ! -x "${extracted}/antares" ]; then
+        die "release archive has an unexpected layout"
+    fi
     local smoke_output
     if ! smoke_output="$("${extracted}/scorpio" --version 2>&1)"; then
         die "downloaded scorpio cannot run on this host: ${smoke_output}. Install a release built for this Linux distribution"
@@ -437,35 +585,61 @@ prepare_directories() {
     run_root install -d "$CONFDIR"
 }
 
+toml_escape() {
+    local value="$1"
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    value="${value//$'\t'/\\t}"
+    printf '%s' "$value"
+}
+
 write_config() {
     local config_tmp="${WORKDIR:-${TMPDIR:-/tmp}}/scorpio.toml"
+    if [ -f "${CONFDIR}/scorpio.toml" ] && [ "$OVERWRITE_CONFIG" -ne 1 ]; then
+        warn "${CONFDIR}/scorpio.toml already exists; leaving its contents unchanged"
+        run_root chown "$TARGET_USER:$TARGET_GROUP" "${CONFDIR}/scorpio.toml"
+        run_root chmod 0640 "${CONFDIR}/scorpio.toml"
+        return 0
+    fi
     if [ "$DRY_RUN" -eq 1 ]; then
         note "would write ${CONFDIR}/scorpio.toml with the supplied URLs and paths"
         return 0
     fi
+    local escaped_base_url escaped_lfs_url escaped_workspace escaped_store_path
+    local escaped_config_file escaped_author escaped_email escaped_data_root
+    escaped_base_url="$(toml_escape "$BASE_URL")"
+    escaped_lfs_url="$(toml_escape "$LFS_URL")"
+    escaped_workspace="$(toml_escape "$WORKSPACE")"
+    escaped_store_path="$(toml_escape "$STORE_PATH")"
+    escaped_config_file="$(toml_escape "$DATA_ROOT/config.toml")"
+    escaped_author="$(toml_escape "$GIT_AUTHOR")"
+    escaped_email="$(toml_escape "$GIT_EMAIL")"
+    escaped_data_root="$(toml_escape "$DATA_ROOT")"
     umask 077
     cat > "$config_tmp" <<EOF
 # Generated by ScorpioFS install.sh. Edit base_url/lfs_url when the backend changes.
-base_url = "$BASE_URL"
-lfs_url = "$LFS_URL"
-workspace = "$WORKSPACE"
-store_path = "$STORE_PATH"
-config_file = "$DATA_ROOT/config.toml"
-git_author = "$GIT_AUTHOR"
-git_email = "$GIT_EMAIL"
+base_url = "$escaped_base_url"
+lfs_url = "$escaped_lfs_url"
+workspace = "$escaped_workspace"
+store_path = "$escaped_store_path"
+config_file = "$escaped_config_file"
+git_author = "$escaped_author"
+git_email = "$escaped_email"
 log_level = "info"
-antares_upper_root = "$DATA_ROOT/antares/upper"
-antares_cl_root = "$DATA_ROOT/antares/cl"
-antares_mount_root = "$DATA_ROOT/antares/mnt"
-antares_state_file = "$DATA_ROOT/antares/state.toml"
+antares_upper_root = "$escaped_data_root/antares/upper"
+antares_cl_root = "$escaped_data_root/antares/cl"
+antares_mount_root = "$escaped_data_root/antares/mnt"
+antares_state_file = "$escaped_data_root/antares/state.toml"
 EOF
-    if [ -f "${CONFDIR}/scorpio.toml" ] && [ "$OVERWRITE_CONFIG" -ne 1 ]; then
-        warn "${CONFDIR}/scorpio.toml already exists; leaving it unchanged"
-        rm -f "$config_tmp"
-        return 0
-    fi
     run_root install -m 0640 -o "$TARGET_USER" -g "$TARGET_GROUP" "$config_tmp" "${CONFDIR}/scorpio.toml"
     rm -f "$config_tmp"
+}
+
+validate_installed_config() {
+    [ "$DRY_RUN" -eq 0 ] || return 0
+    if ! run_root "${PREFIX}/bin/scorpio" --config-path "${CONFDIR}/scorpio.toml" config validate; then
+        die "generated or retained config is invalid: ${CONFDIR}/scorpio.toml"
+    fi
 }
 
 enable_user_allow_other() {
@@ -513,6 +687,8 @@ AmbientCapabilities=CAP_SYS_ADMIN
 CapabilityBoundingSet=CAP_SYS_ADMIN
 WorkingDirectory=${DATA_ROOT}
 ExecStart=${PREFIX}/bin/scorpio --config-path ${CONFDIR}/scorpio.toml serve --http-addr ${HTTP_ADDR}
+ExecStopPost=-/bin/sh -c 'for m in \$(findmnt -rno TARGET --submounts ${DATA_ROOT}/antares/mnt 2>/dev/null | sort -r); do fusermount3 -u -z "\$m"; done'
+ExecStopPost=-/usr/bin/fusermount3 -u -z ${WORKSPACE}
 Restart=on-failure
 RestartSec=5s
 TimeoutStopSec=45
@@ -526,8 +702,16 @@ WantedBy=multi-user.target
 EOF
     run_root install -m 0644 "$unit_tmp" /etc/systemd/system/scorpiofs.service
     run_root systemctl daemon-reload
-    if ! run_root systemctl enable --now scorpiofs.service; then
-        warn "systemd unit installed but could not start; inspect: systemctl status scorpiofs"
+    if ! run_root systemctl enable scorpiofs.service; then
+        die "could not enable scorpiofs.service; inspect: systemctl status scorpiofs"
+    fi
+    local service_action="start"
+    if run_root systemctl is-active --quiet scorpiofs.service; then
+        service_action="restart"
+        note "restarting the active ScorpioFS service to load the new binary and config"
+    fi
+    if ! run_root systemctl "$service_action" scorpiofs.service; then
+        die "systemd unit could not ${service_action}; inspect: systemctl status scorpiofs"
     fi
 }
 
@@ -545,9 +729,8 @@ uninstall() {
 main() {
     parse_args "$@"
     if [ "$DO_UNINSTALL" -eq 1 ]; then uninstall; exit 0; fi
-    if [ "$INTERACTIVE" -eq 1 ] && [ ! -e /dev/tty ] && [ "$ASSUME_YES" -eq 0 ]; then
-        die "interactive input requires a terminal; use --non-interactive with --base-url and --lfs-url"
-    fi
+    apply_environment_options
+    open_interactive_tty
 
     check_tools
     resolve_version
@@ -567,13 +750,14 @@ main() {
     ensure_service_account
     prepare_directories
     write_config
+    validate_installed_config
     enable_user_allow_other
     install_systemd_service
 
     note "installation complete"
     note "config: ${CONFDIR}/scorpio.toml"
     note "check:  ${PREFIX}/bin/scorpio --config-path ${CONFDIR}/scorpio.toml doctor"
-    note "health: curl http://127.0.0.1:${HTTP_ADDR##*:}/health"
+    note "health: curl $(health_endpoint)"
     if [ "$SETUP_SERVICE" -eq 1 ]; then
         note "logs:   journalctl -u scorpiofs -f"
     else

--- a/install.sh
+++ b/install.sh
@@ -56,6 +56,7 @@ RETAIN_CONFIG=0
 EXISTING_SERVICE_USER=""
 EXISTING_SERVICE_ACTIVE=0
 SERVICE_STOPPED_FOR_UPGRADE=0
+SERVICE_HEALTH_CONFIRMED=0
 PREVIOUS_WORKSPACE=""
 PREVIOUS_ANTARES_MOUNT_ROOT=""
 EXTRACTED_RELEASE=""
@@ -74,9 +75,18 @@ BIND_PORT=""
 [ -z "${SCORPIO_STORE_PATH:-}" ] || STORE_PATH_SET=1
 
 cleanup() {
+    local exit_status=$?
+    if [ "$exit_status" -ne 0 ] && [ "$SERVICE_STOPPED_FOR_UPGRADE" -eq 1 ] && \
+        [ "$SERVICE_HEALTH_CONFIRMED" -ne 1 ] && command -v systemctl >/dev/null 2>&1; then
+        warn "installation failed after stopping scorpiofs.service; attempting to restore the managed service"
+        if ! run_root systemctl start scorpiofs.service; then
+            warn "could not restore scorpiofs.service; inspect: systemctl status scorpiofs"
+        fi
+    fi
     if [ -n "${WORKDIR:-}" ] && [ -d "$WORKDIR" ]; then
         rm -rf "$WORKDIR"
     fi
+    return "$exit_status"
 }
 trap cleanup EXIT
 
@@ -1026,8 +1036,11 @@ prepare_directories() {
     )
     if ! path_is_mount_target "$WORKSPACE"; then directories+=("$WORKSPACE"); fi
     if ! path_is_mount_target "$ANTARES_MOUNT_ROOT"; then directories+=("$ANTARES_MOUNT_ROOT"); fi
-    run_root install -d -o "$TARGET_USER" -g "$TARGET_GROUP" "${directories[@]}"
-    run_root install -d "$CONFDIR"
+    # mkdir preserves modes on existing directories; install -d would reset
+    # hardened data directories to its 0755 default during every upgrade.
+    run_root mkdir -p -m 0755 -- "${directories[@]}"
+    run_root chown "$TARGET_USER:$TARGET_GROUP" "${directories[@]}"
+    run_root mkdir -p -m 0755 -- "$CONFDIR"
 }
 
 find_mount_fstype() {
@@ -1321,6 +1334,30 @@ EOF
     if ! run_root systemctl "$service_action" scorpiofs.service; then
         die "systemd unit could not ${service_action}; inspect: systemctl status scorpiofs"
     fi
+    wait_for_service_health
+}
+
+wait_for_service_health() {
+    local endpoint attempt
+    endpoint="$(health_endpoint)"
+    for ((attempt = 1; attempt <= 30; attempt++)); do
+        if ! run_root systemctl is-active --quiet scorpiofs.service; then
+            die "scorpiofs.service is not active after starting; inspect: systemctl status scorpiofs"
+        fi
+        if [ "$DOWNLOADER" = "curl" ]; then
+            if curl -fsS --connect-timeout 2 --max-time 5 "$endpoint" >/dev/null 2>&1; then
+                SERVICE_HEALTH_CONFIRMED=1
+                note "scorpiofs.service is healthy at ${endpoint}"
+                return 0
+            fi
+        elif wget -q --timeout=2 --tries=1 -O /dev/null "$endpoint"; then
+            SERVICE_HEALTH_CONFIRMED=1
+            note "scorpiofs.service is healthy at ${endpoint}"
+            return 0
+        fi
+        sleep 1
+    done
+    die "scorpiofs.service did not become healthy at ${endpoint}; inspect: systemctl status scorpiofs"
 }
 
 uninstall() {

--- a/install.sh
+++ b/install.sh
@@ -439,6 +439,8 @@ common_path_ancestor() {
 }
 
 infer_data_root() {
+    local failure_message="${1:-cannot infer data-root from an all-relative retained config; pass --data-root}"
+    local root_label="${2:-data-root}"
     local value
     local -a anchors=()
     for value in "$WORKSPACE" "$STORE_PATH" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT" "$ANTARES_MOUNT_ROOT"; do
@@ -447,10 +449,9 @@ infer_data_root() {
     for value in "$CONFIG_FILE" "$ANTARES_STATE_FILE"; do
         if [[ "$value" == /* ]]; then anchors+=("$(dirname -- "$value")"); fi
     done
-    [ "${#anchors[@]}" -gt 0 ] || \
-        die "cannot infer data-root from an all-relative retained config; pass --data-root"
+    [ "${#anchors[@]}" -gt 0 ] || die "$failure_message"
     DATA_ROOT="$(common_path_ancestor "${anchors[@]}")"
-    note "using data-root inferred from retained config: $DATA_ROOT"
+    note "using $root_label inferred from retained config: $DATA_ROOT"
 }
 
 resolve_relative_runtime_paths() {
@@ -521,24 +522,23 @@ load_configured_runtime_paths() {
 }
 
 prepare_effective_runtime_paths() {
-    local binary="$1" selected_root_nonempty=0 load_existing_paths=0
+    local binary="$1" selected_root_nonempty=0 target_data_root="$DATA_ROOT"
     if [ -d "$DATA_ROOT" ] && [ -n "$(find "$DATA_ROOT" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
         selected_root_nonempty=1
     fi
 
-    if [ "$RETAIN_CONFIG" -eq 1 ]; then
-        load_existing_paths=1
-    elif [ "$EXISTING_CONFIG" -eq 1 ] && \
-        { [ "$DATA_ROOT_SET" -eq 0 ] || [ "$selected_root_nonempty" -eq 1 ]; }; then
-        # Before overwriting a nonempty root, prove that the old config belongs
-        # to it. An unspecified root is inferred from that same old config.
-        load_existing_paths=1
-    fi
-
-    if [ "$load_existing_paths" -eq 1 ]; then
+    if [ "$EXISTING_CONFIG" -eq 1 ]; then
         load_configured_runtime_paths "$binary"
         normalize_runtime_paths
-        if [ "$DATA_ROOT_SET" -eq 0 ]; then infer_data_root; fi
+        if [ "$DATA_ROOT_SET" -eq 0 ]; then
+            infer_data_root
+        elif [ "$RETAIN_CONFIG" -eq 1 ] || [ "$selected_root_nonempty" -eq 1 ]; then
+            DATA_ROOT="$target_data_root"
+        else
+            infer_data_root \
+                "cannot resolve previous mount paths from an all-relative config while changing to an empty data-root; rerun with the previous data-root or unmount the old paths manually" \
+                "previous data-root"
+        fi
         resolve_relative_runtime_paths
         validate_runtime_paths
         PREVIOUS_WORKSPACE="$WORKSPACE"
@@ -550,6 +550,7 @@ prepare_effective_runtime_paths() {
         return 0
     fi
 
+    DATA_ROOT="$target_data_root"
     set_generated_runtime_paths
     canonicalize_runtime_paths
     validate_runtime_paths

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,7 @@ STORE_PATH_SET=0
 EXISTING_CONFIG=0
 RETAIN_CONFIG=0
 EXISTING_SERVICE_USER=""
+SERVICE_STOPPED_FOR_MIGRATION=0
 REQUESTED_WORKSPACE=""
 REQUESTED_STORE_PATH=""
 WORKDIR=""
@@ -429,7 +430,11 @@ run_scorpio_config_without_overrides() {
             SCORPIO_*) command+=(-u "$variable") ;;
         esac
     done < <(compgen -e)
-    run_root "${command[@]}" "$binary" --config-path "${CONFDIR}/scorpio.toml" config "$@"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        "${command[@]}" "$binary" --config-path "${CONFDIR}/scorpio.toml" config "$@"
+    else
+        run_root "${command[@]}" "$binary" --config-path "${CONFDIR}/scorpio.toml" config "$@"
+    fi
 }
 
 load_configured_runtime_paths() {
@@ -483,7 +488,6 @@ prepare_effective_runtime_paths() {
 }
 
 detect_existing_service_user() {
-    [ "$SETUP_SERVICE" -eq 0 ] && [ "$EXISTING_CONFIG" -eq 1 ] || return 0
     local candidate=""
     if command -v systemctl >/dev/null 2>&1; then
         candidate="$(systemctl show --property=User --value scorpiofs.service 2>/dev/null || true)"
@@ -497,6 +501,19 @@ detect_existing_service_user() {
     getent passwd "$candidate" >/dev/null 2>&1 || \
         die "existing scorpiofs.service user does not exist: $candidate"
     EXISTING_SERVICE_USER="$candidate"
+}
+
+stop_active_service_for_user_migration() {
+    [ "$SETUP_SERVICE" -eq 1 ] || return 0
+    [ -n "$EXISTING_SERVICE_USER" ] || return 0
+    [ "$EXISTING_SERVICE_USER" != "$SERVICE_USER" ] || return 0
+    if run_root systemctl is-active --quiet scorpiofs.service; then
+        note "stopping the active service before migrating data from $EXISTING_SERVICE_USER to $SERVICE_USER"
+        if ! run_root systemctl stop scorpiofs.service; then
+            die "could not stop scorpiofs.service before changing its service user"
+        fi
+        SERVICE_STOPPED_FOR_MIGRATION=1
+    fi
 }
 
 validate_service_manager() {
@@ -751,7 +768,7 @@ validate_inputs() {
 }
 
 install_binaries() {
-    local target tarball base url sumurl extracted
+    local target tarball base url sumurl extracted installed_binary
     target="$(detect_target)"
     tarball="scorpiofs-${VERSION}-${target}.tar.gz"
     base="${RELEASE_BASE_URL%/}/${VERSION}"
@@ -759,6 +776,13 @@ install_binaries() {
     sumurl="${url}.sha256"
 
     if [ "$DRY_RUN" -eq 1 ]; then
+        if [ "$EXISTING_CONFIG" -eq 1 ]; then
+            installed_binary="${PREFIX}/bin/scorpio"
+            [ -x "$installed_binary" ] || \
+                die "dry-run cannot faithfully resolve retained config without $installed_binary"
+            WORKDIR="$(mktemp -d)"
+            prepare_effective_runtime_paths "$installed_binary"
+        fi
         note "would download ${url}"
         note "would verify ${sumurl} with SHA256"
         note "would install ${PREFIX}/bin/scorpio and ${PREFIX}/bin/antares"
@@ -847,14 +871,12 @@ prepare_directories() {
     run_root install -d "$CONFDIR"
 }
 
-reconcile_runtime_directories() {
+validate_runtime_migration_mounts() {
     local runtime_dir mount_target mount_targets
-    # These are persistent local data trees. Workspace and mount roots are
-    # intentionally excluded because they may currently be FUSE mountpoints.
+    mount_targets="$(findmnt --noheadings --raw --output TARGET)" || \
+        die "could not inspect mounts before migrating runtime ownership"
     for runtime_dir in "$STORE_PATH" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT"; do
         if [ -d "$runtime_dir" ]; then
-            mount_targets="$(findmnt --noheadings --raw --output TARGET)" || \
-                die "could not inspect mounts before migrating ownership under $runtime_dir"
             while IFS= read -r mount_target; do
                 case "$mount_target" in
                     "$runtime_dir"/*)
@@ -862,6 +884,17 @@ reconcile_runtime_directories() {
                         ;;
                 esac
             done <<<"$mount_targets"
+        fi
+    done
+}
+
+reconcile_runtime_directories() {
+    local runtime_dir
+    # These are persistent local data trees. Workspace and mount roots are
+    # intentionally excluded because they may currently be FUSE mountpoints.
+    validate_runtime_migration_mounts
+    for runtime_dir in "$STORE_PATH" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT"; do
+        if [ -d "$runtime_dir" ]; then
             run_root chown -R -h -P "$TARGET_USER:$TARGET_GROUP" -- "$runtime_dir"
         fi
     done
@@ -997,7 +1030,9 @@ EOF
         die "could not enable scorpiofs.service; inspect: systemctl status scorpiofs"
     fi
     local service_action="start"
-    if run_root systemctl is-active --quiet scorpiofs.service; then
+    if [ "$SERVICE_STOPPED_FOR_MIGRATION" -eq 1 ]; then
+        note "starting ScorpioFS with the new service user"
+    elif run_root systemctl is-active --quiet scorpiofs.service; then
         service_action="restart"
         note "restarting the active ScorpioFS service to load the new binary and config"
     fi
@@ -1042,7 +1077,9 @@ main() {
     check_runtime_tools
     check_fuse
     install_binaries
+    validate_runtime_migration_mounts
     ensure_service_account
+    stop_active_service_for_user_migration
     prepare_directories
     reconcile_runtime_directories
     reconcile_runtime_files

--- a/install.sh
+++ b/install.sh
@@ -450,7 +450,7 @@ infer_data_root() {
         if [[ "$value" == /* ]]; then anchors+=("$(dirname -- "$value")"); fi
     done
     [ "${#anchors[@]}" -gt 0 ] || die "$failure_message"
-    DATA_ROOT="$(common_path_ancestor "${anchors[@]}")"
+    DATA_ROOT="$(realpath -m -- "$(common_path_ancestor "${anchors[@]}")")"
     note "using $root_label inferred from retained config: $DATA_ROOT"
 }
 
@@ -1047,7 +1047,15 @@ recover_stale_runtime_mounts() {
         if [ -n "$EXISTING_SERVICE_USER" ]; then
             probe=(runuser -u "$EXISTING_SERVICE_USER" -- "${probe[@]}")
         fi
-        if run_root "${probe[@]}" && [ "$detach_managed_mounts" -ne 1 ]; then
+        # Mount health is a read-only check, so dry-runs must execute it to
+        # preserve the same stale-versus-active decision as a real install.
+        local probe_succeeded=0
+        if [ "$DRY_RUN" -eq 1 ]; then
+            if "${probe[@]}"; then probe_succeeded=1; fi
+        elif run_root "${probe[@]}"; then
+            probe_succeeded=1
+        fi
+        if [ "$probe_succeeded" -eq 1 ] && [ "$detach_managed_mounts" -ne 1 ]; then
             if [ "$SETUP_SERVICE" -eq 1 ] && [ -z "$EXISTING_SERVICE_USER" ]; then
                 die "$mount_field is actively mounted at $mount_root by an unmanaged process; stop the ScorpioFS daemon, unmount this path, and retry"
             fi

--- a/install.sh
+++ b/install.sh
@@ -853,7 +853,7 @@ reconcile_runtime_directories() {
     # intentionally excluded because they may currently be FUSE mountpoints.
     for runtime_dir in "$STORE_PATH" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT"; do
         if [ -d "$runtime_dir" ]; then
-            mount_targets="$(findmnt --list --noheadings --raw --output TARGET)" || \
+            mount_targets="$(findmnt --noheadings --raw --output TARGET)" || \
                 die "could not inspect mounts before migrating ownership under $runtime_dir"
             while IFS= read -r mount_target; do
                 case "$mount_target" in

--- a/install.sh
+++ b/install.sh
@@ -1161,6 +1161,7 @@ validate_service_config_traversal() {
 }
 
 prepare_directories() {
+    local path parent
     local -a directories
     if [ "$SETUP_SERVICE" -eq 1 ]; then
         TARGET_USER="$SERVICE_USER"
@@ -1184,6 +1185,15 @@ prepare_directories() {
         "$DATA_ROOT" "$STORE_PATH" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT"
         "$(dirname -- "$CONFIG_FILE")" "$(dirname -- "$ANTARES_STATE_FILE")"
     )
+    for path in "$STORE_PATH" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT" \
+        "$CONFIG_FILE" "$ANTARES_STATE_FILE"; do
+        parent="$(dirname -- "$path")"
+        while [[ "$parent" == "$DATA_ROOT"/* ]]; do
+            directories+=("$parent")
+            [ "$parent" = "$DATA_ROOT" ] && break
+            parent="$(dirname -- "$parent")"
+        done
+    done
     if ! path_is_mount_target "$WORKSPACE"; then directories+=("$WORKSPACE"); fi
     if ! path_is_mount_target "$ANTARES_MOUNT_ROOT"; then directories+=("$ANTARES_MOUNT_ROOT"); fi
     # mkdir preserves modes on existing directories; install -d would reset
@@ -1267,6 +1277,13 @@ recover_stale_runtime_mounts() {
         probe=(timeout 15 bash -c 'stat -L -- "$1" >/dev/null 2>&1' bash "$mount_root")
         if [ -n "$EXISTING_SERVICE_USER" ]; then
             probe=(runuser -u "$EXISTING_SERVICE_USER" -- "${probe[@]}")
+            if [ "$DRY_RUN" -eq 1 ] && [ "$(id -u)" -ne 0 ] && [ -z "$SUDO_BIN" ]; then
+                command -v sudo >/dev/null 2>&1 || \
+                    die "sudo is required to inspect managed FUSE mounts during dry-run"
+                sudo -n -v || \
+                    die "could not obtain non-interactive sudo privileges to inspect managed FUSE mounts"
+                probe=(sudo -n "${probe[@]}")
+            fi
         fi
         # Mount health is a read-only check, so dry-runs must execute it to
         # preserve the same stale-versus-active decision as a real install.
@@ -1329,7 +1346,7 @@ reconcile_runtime_directories() {
     # intentionally excluded because they may currently be FUSE mountpoints.
     validate_runtime_migration_mounts
     for runtime_dir in "$STORE_PATH" "$ANTARES_UPPER_ROOT" "$ANTARES_CL_ROOT"; do
-        if [ -d "$runtime_dir" ]; then
+        if run_readonly test -d "$runtime_dir"; then
             run_root chown -R -h -P "$TARGET_USER:$TARGET_GROUP" -- "$runtime_dir"
         fi
     done
@@ -1338,7 +1355,7 @@ reconcile_runtime_directories() {
 reconcile_runtime_files() {
     local runtime_file
     for runtime_file in "$CONFIG_FILE" "$ANTARES_STATE_FILE"; do
-        if [ -e "$runtime_file" ]; then
+        if run_readonly test -e "$runtime_file"; then
             run_root chown "$TARGET_USER:$TARGET_GROUP" "$runtime_file"
         fi
     done

--- a/script/README.md
+++ b/script/README.md
@@ -9,6 +9,8 @@ developer-local paths (test data is created under `/tmp`).
 | `mktestdirs.sh` | Create empty scratch dirs for overlay/FUSE experiments. | `script/mktestdirs.sh` |
 | `run.sh` | Generate a small deep directory tree (10 × 1 MB files) under `/tmp`. | `script/run.sh` |
 | `run_1000_files.sh` | Generate a larger tree (~1000 files) under `/tmp`. | `script/run_1000_files.sh` |
+| `test_installer.sh` | Exercise installer input and safety validation without system changes. | `script/test_installer.sh` |
+| `test_installer_systemd.sh` | Verify generated mount cleanup and upgrade restart using mocked systemd commands. | `sudo script/test_installer_systemd.sh <version> <release-url> <test-root>` |
 | `fuse_test.py` | Python FUSE throughput/latency benchmark with plots. | `python3 script/fuse_test.py --help` |
 | `log_analysis.py` | Extract abnormal/unmatched request IDs from a ScorpioFS log (writes `output.txt`). | `python3 script/log_analysis.py` |
 

--- a/script/test_installer.sh
+++ b/script/test_installer.sh
@@ -88,6 +88,14 @@ if [[ "$output" != *"systemctl is required for service setup"* ]]; then
     exit 1
 fi
 
+mkdir -p "$test_root/missing-bin-etc"
+: >"$test_root/missing-bin-etc/scorpio.toml"
+expect_failure "retained dry-run without installed binary" \
+    "dry-run cannot faithfully resolve retained config" \
+    "${common[@]}" \
+    --prefix "$test_root/missing-bin-prefix" \
+    --config-dir "$test_root/missing-bin-etc"
+
 ln -s / "$test_root/root-link"
 expect_failure "symlinked ancestor to broad root" "data-root is too broad" \
     "${common[@]}" --data-root "$test_root/root-link/home" \

--- a/script/test_installer.sh
+++ b/script/test_installer.sh
@@ -42,6 +42,15 @@ bash "$installer" "${common[@]}" \
     --lfs-url 'http://[::1]:8000/lfs' \
     --http-addr '[::1]:2725' >/dev/null
 
+grep() {
+    if [[ " $* " == *" /etc/fuse.conf "* ]]; then return 1; fi
+    command grep "$@"
+}
+export -f grep
+expect_failure "dry-run without user_allow_other" "user_allow_other is required" \
+    "${common[@]}"
+unset -f grep
+
 interactive_public=(
     --version v0.0.0-test
     --dry-run
@@ -125,8 +134,8 @@ fi
 
 mkdir -p "$test_root/missing-bin-etc"
 : >"$test_root/missing-bin-etc/scorpio.toml"
-expect_failure "retained dry-run without installed binary" \
-    "dry-run cannot faithfully resolve retained config" \
+expect_failure "retained dry-run without target release" \
+    "release asset unavailable" \
     "${common[@]}" \
     --prefix "$test_root/missing-bin-prefix" \
     --config-dir "$test_root/missing-bin-etc"

--- a/script/test_installer.sh
+++ b/script/test_installer.sh
@@ -67,6 +67,8 @@ if [[ "$output" != *"health: curl http://192.168.1.10:2725/health"* ]]; then
 fi
 
 expect_failure "missing URL host" "must include a host" "${common[@]}" --base-url http://
+expect_failure "URL control character" "base_url must not contain control characters" \
+    "${common[@]}" --base-url $'https://mega.example.com/a\bpath'
 expect_failure "URL port overflow" "between 1 and 65535" "${common[@]}" --lfs-url http://host:99999
 expect_failure "bind port overflow" "between 1 and 65535" "${common[@]}" --http-addr 127.0.0.1:99999
 expect_failure "unbracketed IPv6 bind" "IPv4:port or [IPv6]:port" "${common[@]}" --http-addr ::1:2725

--- a/script/test_installer.sh
+++ b/script/test_installer.sh
@@ -61,6 +61,33 @@ expect_failure "cleanup shell metacharacter" "unsafe for shell or systemd" \
     "${common[@]}" --data-root "$test_root/scorpio;false" \
     --workspace "$test_root/scorpio;false/mount" --store-path "$test_root/scorpio;false/store"
 
+no_systemctl_bin="$test_root/no-systemctl-bin"
+mkdir -p "$no_systemctl_bin"
+for tool in curl tar realpath find findmnt; do
+    ln -s "$(command -v "$tool")" "$no_systemctl_bin/$tool"
+done
+if output="$(PATH="$no_systemctl_bin" /bin/bash "$installer" \
+    --version v0.0.0-test \
+    --non-interactive \
+    --dry-run \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://mega.example.com \
+    --lfs-url https://mega.example.com/lfs \
+    --prefix "$test_root/service-prefix" \
+    --config-dir "$test_root/service-etc" \
+    --data-root "$test_root/service-data" \
+    --workspace "$test_root/service-data/mount" \
+    --store-path "$test_root/service-data/store" \
+    --http-addr 127.0.0.1:2725 2>&1)"; then
+    printf 'expected failure without systemctl\n' >&2
+    exit 1
+fi
+if [[ "$output" != *"systemctl is required for service setup"* ]]; then
+    printf 'unexpected missing-systemctl error:\n%s\n' "$output" >&2
+    exit 1
+fi
+
 ln -s / "$test_root/root-link"
 expect_failure "symlinked ancestor to broad root" "data-root is too broad" \
     "${common[@]}" --data-root "$test_root/root-link/home" \

--- a/script/test_installer.sh
+++ b/script/test_installer.sh
@@ -12,7 +12,7 @@ common=(
     --dry-run
     --no-deps
     --no-service
-    --no-user-allow-other
+    --enable-user-allow-other
     --base-url https://mega.example.com
     --lfs-url https://mega.example.com/lfs
     --prefix "$test_root/prefix"
@@ -48,7 +48,7 @@ grep() {
 }
 export -f grep
 expect_failure "dry-run without user_allow_other" "user_allow_other is required" \
-    "${common[@]}"
+    "${common[@]}" --no-user-allow-other
 unset -f grep
 
 interactive_public=(
@@ -56,7 +56,7 @@ interactive_public=(
     --dry-run
     --no-deps
     --no-service
-    --no-user-allow-other
+    --enable-user-allow-other
     --yes
     --allow-public-api
     --base-url https://mega.example.com

--- a/script/test_installer.sh
+++ b/script/test_installer.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+installer="${repo_root}/install.sh"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+common=(
+    --version v0.0.0-test
+    --non-interactive
+    --dry-run
+    --no-deps
+    --no-service
+    --no-user-allow-other
+    --base-url https://mega.example.com
+    --lfs-url https://mega.example.com/lfs
+    --prefix "$test_root/prefix"
+    --config-dir "$test_root/etc"
+    --data-root "$test_root/data"
+    --workspace "$test_root/data/mount"
+    --store-path "$test_root/data/store"
+    --http-addr 127.0.0.1:2725
+)
+
+expect_failure() {
+    local label="$1" expected="$2"
+    shift 2
+    if output="$(bash "$installer" "$@" 2>&1)"; then
+        printf 'expected failure for %s\n' "$label" >&2
+        exit 1
+    fi
+    if [[ "$output" != *"$expected"* ]]; then
+        printf 'unexpected error for %s:\n%s\n' "$label" "$output" >&2
+        exit 1
+    fi
+}
+
+bash "$installer" "${common[@]}" --http-addr 192.168.1.10:2725 --allow-public-api >/dev/null
+bash "$installer" "${common[@]}" \
+    --base-url 'http://[::1]:8000' \
+    --lfs-url 'http://[::1]:8000/lfs' \
+    --http-addr '[::1]:2725' >/dev/null
+
+expect_failure "missing URL host" "must include a host" "${common[@]}" --base-url http://
+expect_failure "URL port overflow" "between 1 and 65535" "${common[@]}" --lfs-url http://host:99999
+expect_failure "bind port overflow" "between 1 and 65535" "${common[@]}" --http-addr 127.0.0.1:99999
+expect_failure "unbracketed IPv6 bind" "IPv4:port or [IPv6]:port" "${common[@]}" --http-addr ::1:2725
+expect_failure "unauthorized public bind" "without --allow-public-api" \
+    "${common[@]}" --http-addr 192.168.1.10:2725
+expect_failure "filesystem root data path" "data-root is too broad" \
+    "${common[@]}" --data-root / --workspace /mount --store-path /store
+expect_failure "broad /var/lib data path" "data-root is too broad" \
+    "${common[@]}" --data-root /var/lib --workspace /var/lib/mount --store-path /var/lib/store
+expect_failure "workspace outside data root" "workspace must be inside data-root" \
+    "${common[@]}" --workspace /home
+expect_failure "systemd path specifier" "unsafe for shell or systemd" \
+    "${common[@]}" --data-root "$test_root/scorpio%Q" \
+    --workspace "$test_root/scorpio%Q/mount" --store-path "$test_root/scorpio%Q/store"
+
+if command -v setsid >/dev/null 2>&1; then
+    if output="$(setsid bash "$installer" --version v0.0.0-test --dry-run </dev/null 2>&1)"; then
+        printf 'expected failure without a controlling terminal\n' >&2
+        exit 1
+    fi
+    if [[ "$output" != *"requires a controlling terminal"* ]]; then
+        printf 'unexpected no-terminal error:\n%s\n' "$output" >&2
+        exit 1
+    fi
+fi
+
+printf 'installer validation tests passed\n'

--- a/script/test_installer.sh
+++ b/script/test_installer.sh
@@ -42,6 +42,30 @@ bash "$installer" "${common[@]}" \
     --lfs-url 'http://[::1]:8000/lfs' \
     --http-addr '[::1]:2725' >/dev/null
 
+interactive_public=(
+    --version v0.0.0-test
+    --dry-run
+    --no-deps
+    --no-service
+    --no-user-allow-other
+    --yes
+    --allow-public-api
+    --base-url https://mega.example.com
+    --lfs-url https://mega.example.com/lfs
+    --prefix "$test_root/interactive-prefix"
+    --config-dir "$test_root/interactive-etc"
+    --data-root "$test_root/interactive-data"
+    --workspace "$test_root/interactive-data/mount"
+    --store-path "$test_root/interactive-data/store"
+    --http-addr 192.168.1.10:2725
+)
+interactive_command="$(printf '%q ' bash "$installer" "${interactive_public[@]}")"
+output="$(script -qec "$interactive_command" /dev/null)"
+if [[ "$output" != *"health: curl http://192.168.1.10:2725/health"* ]]; then
+    printf 'interactive --allow-public-api did not preserve the explicit bind:\n%s\n' "$output" >&2
+    exit 1
+fi
+
 expect_failure "missing URL host" "must include a host" "${common[@]}" --base-url http://
 expect_failure "URL port overflow" "between 1 and 65535" "${common[@]}" --lfs-url http://host:99999
 expect_failure "bind port overflow" "between 1 and 65535" "${common[@]}" --http-addr 127.0.0.1:99999

--- a/script/test_installer.sh
+++ b/script/test_installer.sh
@@ -57,6 +57,20 @@ expect_failure "workspace outside data root" "workspace must be inside data-root
 expect_failure "systemd path specifier" "unsafe for shell or systemd" \
     "${common[@]}" --data-root "$test_root/scorpio%Q" \
     --workspace "$test_root/scorpio%Q/mount" --store-path "$test_root/scorpio%Q/store"
+expect_failure "cleanup shell metacharacter" "unsafe for shell or systemd" \
+    "${common[@]}" --data-root "$test_root/scorpio;false" \
+    --workspace "$test_root/scorpio;false/mount" --store-path "$test_root/scorpio;false/store"
+
+ln -s / "$test_root/root-link"
+expect_failure "symlinked ancestor to broad root" "data-root is too broad" \
+    "${common[@]}" --data-root "$test_root/root-link/home" \
+    --workspace "$test_root/root-link/home/mount" --store-path "$test_root/root-link/home/store"
+
+mkdir -p "$test_root/existing-data"
+: >"$test_root/existing-data/unrelated-file"
+expect_failure "nonempty unowned data root" "refusing to change ownership of a nonempty data-root" \
+    "${common[@]}" --data-root "$test_root/existing-data" \
+    --workspace "$test_root/existing-data/mount" --store-path "$test_root/existing-data/store"
 
 if command -v setsid >/dev/null 2>&1; then
     if output="$(setsid bash "$installer" --version v0.0.0-test --dry-run </dev/null 2>&1)"; then

--- a/script/test_installer.sh
+++ b/script/test_installer.sh
@@ -54,6 +54,8 @@ expect_failure "broad /var/lib data path" "data-root is too broad" \
     "${common[@]}" --data-root /var/lib --workspace /var/lib/mount --store-path /var/lib/store
 expect_failure "workspace outside data root" "workspace must be inside data-root" \
     "${common[@]}" --workspace /home
+expect_failure "workspace overlaps store" "workspace must not overlap store-path" \
+    "${common[@]}" --store-path "$test_root/data/mount"
 expect_failure "systemd path specifier" "unsafe for shell or systemd" \
     "${common[@]}" --data-root "$test_root/scorpio%Q" \
     --workspace "$test_root/scorpio%Q/mount" --store-path "$test_root/scorpio%Q/store"

--- a/script/test_installer.sh
+++ b/script/test_installer.sh
@@ -56,12 +56,19 @@ expect_failure "workspace outside data root" "workspace must be inside data-root
     "${common[@]}" --workspace /home
 expect_failure "workspace overlaps store" "workspace must not overlap store-path" \
     "${common[@]}" --store-path "$test_root/data/mount"
+expect_failure "workspace contains installed binary" "workspace must not contain scorpio-binary" \
+    "${common[@]}" --prefix "$test_root/data/mount/tools"
+expect_failure "Antares mount root contains main config" "antares-mount-root must not contain main-config" \
+    "${common[@]}" --config-dir "$test_root/data/antares/mnt/config"
 expect_failure "systemd path specifier" "unsafe for shell or systemd" \
     "${common[@]}" --data-root "$test_root/scorpio%Q" \
     --workspace "$test_root/scorpio%Q/mount" --store-path "$test_root/scorpio%Q/store"
 expect_failure "cleanup shell metacharacter" "unsafe for shell or systemd" \
     "${common[@]}" --data-root "$test_root/scorpio;false" \
     --workspace "$test_root/scorpio;false/mount" --store-path "$test_root/scorpio;false/store"
+SCORPIO_GIT_AUTHOR=$'Bob\bBuilder' expect_failure \
+    "TOML author control character" "git author must not contain control characters" \
+    "${common[@]}"
 
 no_systemctl_bin="$test_root/no-systemctl-bin"
 mkdir -p "$no_systemctl_bin"

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -196,12 +196,13 @@ test ! -e "${unmanaged_root}/prefix/bin/scorpio"
 
 if [ "$service_user" != root ]; then
     inaccessible_root="${test_root}/inaccessible-data"
+    inaccessible_user=nobody
     mkdir -p "${inaccessible_root}/etc" "${inaccessible_root}/data"
-    chown "$service_user" "${inaccessible_root}/etc"
+    chown "$inaccessible_user" "${inaccessible_root}/etc"
     chmod 0711 "${inaccessible_root}/data"
     : >"${inaccessible_root}/data/sentinel"
     chown root:root "${inaccessible_root}/data/sentinel"
-    if inaccessible_output="$(sudo -u "$service_user" -H env -u SUDO_USER \
+    if inaccessible_output="$(sudo -u "$inaccessible_user" -H env -u SUDO_USER \
         bash "${repo_root}/install.sh" \
             --version "$version" \
             --release-base-url "$release_base_url" \

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -187,6 +187,25 @@ grep -Fxq 'is-active --quiet scorpiofs.service' "$systemctl_log"
 grep -Fxq 'restart scorpiofs.service' "$systemctl_log"
 grep -Fxq "fusermount3 -u -z ${test_root}/data/mount" "$systemctl_log"
 
+MOCK_STALE_MOUNT="${test_root}/data/mount" \
+SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
+    --version "$version" \
+    --release-base-url "$release_base_url" \
+    --non-interactive \
+    --dry-run \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://ignored.example.com \
+    --lfs-url https://ignored.example.com/lfs \
+    --prefix "${test_root}/prefix" \
+    --config-dir "${test_root}/etc" \
+    --data-root "${test_root}/data" \
+    --workspace "${test_root}/data/mount" \
+    --store-path "${test_root}/data/store" \
+    --http-addr 127.0.0.1:2925 >"${test_root}/mounted-dry-run.log"
+grep -Fq "[dry-run] fusermount3 -u -z ${test_root}/data/mount" \
+    "${test_root}/mounted-dry-run.log"
+
 : >"$systemctl_log"
 new_workspace="${test_root}/data/mount-new"
 MOCK_ACTIVE_MOUNT="${test_root}/data/mount" \
@@ -210,6 +229,49 @@ grep -Fxq 'stop scorpiofs.service' "$systemctl_log"
 grep -Fxq "fusermount3 -u -z ${test_root}/data/mount" "$systemctl_log"
 grep -Fxq 'start scorpiofs.service' "$systemctl_log"
 grep -Fq "ExecStopPost=-/usr/bin/fusermount3 -u -z ${new_workspace}" "$unit_capture"
+
+if [ "$service_user" != root ] && \
+    sudo -u "$service_user" -H env -u SUDO_USER sudo -n -v; then
+    protected_root="${test_root}/protected-config"
+    SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
+        --version "$version" \
+        --release-base-url "$release_base_url" \
+        --non-interactive \
+        --overwrite-config \
+        --no-service \
+        --no-deps \
+        --no-user-allow-other \
+        --base-url https://protected.example.com \
+        --lfs-url https://protected.example.com/lfs \
+        --prefix "${protected_root}/prefix" \
+        --config-dir "${protected_root}/etc" \
+        --data-root "${protected_root}/data" \
+        --workspace "${protected_root}/data/mount" \
+        --store-path "${protected_root}/data/store" \
+        --http-addr 127.0.0.1:2925
+    chown root:root "${protected_root}/etc"
+    chmod 0750 "${protected_root}/etc"
+    protected_upgrade_output="$(sudo -u "$service_user" -H env -u SUDO_USER \
+        bash "${repo_root}/install.sh" \
+            --version "$version" \
+            --release-base-url "$release_base_url" \
+            --non-interactive \
+            --no-service \
+            --no-deps \
+            --no-user-allow-other \
+            --base-url https://ignored.example.com \
+            --lfs-url https://ignored.example.com/lfs \
+            --prefix "${protected_root}/prefix" \
+            --config-dir "${protected_root}/etc" \
+            --data-root "${protected_root}/data" \
+            --workspace "${protected_root}/data/mount" \
+            --store-path "${protected_root}/data/store" \
+            --http-addr 127.0.0.1:2925)"
+    grep -Fq "using runtime paths from retained ${protected_root}/etc/scorpio.toml" \
+        <<<"$protected_upgrade_output"
+    grep -Fq 'base_url = "https://protected.example.com"' \
+        "${protected_root}/etc/scorpio.toml"
+fi
 
 SCORPIO_SERVICE_USER=nobody bash "${repo_root}/install.sh" \
     --version "$version" \

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -355,4 +355,22 @@ grep -Fq "ExecStopPost=-/usr/bin/fusermount3 -u -z ${migrated_data_root}/mount" 
     "$unit_capture"
 grep -Fq "workspace = \"${migrated_data_root}/mount\"" "${test_root}/etc/scorpio.toml"
 
+symlinked_data_root="${test_root}/data-link"
+ln -s "$migrated_data_root" "$symlinked_data_root"
+sed -i "s|${migrated_data_root}|${symlinked_data_root}|g" "${test_root}/etc/scorpio.toml"
+SCORPIO_SERVICE_USER=nobody bash "${repo_root}/install.sh" \
+    --version "$version" \
+    --release-base-url "$release_base_url" \
+    --non-interactive \
+    --no-service \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://ignored.example.com \
+    --lfs-url https://ignored.example.com/lfs \
+    --prefix "${test_root}/prefix" \
+    --config-dir "${test_root}/etc" \
+    --http-addr 127.0.0.1:2925 >"${test_root}/symlinked-root.log"
+grep -Fq "using data-root inferred from retained config: ${migrated_data_root}" \
+    "${test_root}/symlinked-root.log"
+
 printf 'installer systemd generation and restart test passed\n'

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -277,7 +277,11 @@ SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
     --data-root "${test_root}/data" \
     --workspace "${test_root}/data/mount" \
     --store-path "${test_root}/data/store" \
-    --http-addr 127.0.0.1:2925 >"${test_root}/antares-child-mount.log"
+    --http-addr 127.0.0.1:2925 >"${test_root}/antares-child-mount.log" 2>&1 || {
+        printf 'Antares child-mount installer invocation failed:\n' >&2
+        cat "${test_root}/antares-child-mount.log" >&2
+        exit 1
+    }
 assert_systemctl_log_line "fusermount3 -u -z ${antares_job_mount}"
 
 assert_unit_contains 'ExecStopPost=-/bin/sh -c'

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -236,7 +236,11 @@ if [ "$service_user" != root ]; then
         printf 'installer accepted an inaccessible nonempty data-root\n' >&2
         exit 1
     fi
-    grep -Fq 'could not inspect data-root; refusing to change ownership' <<<"$inaccessible_output"
+    if ! grep -Eq 'could not inspect data-root; refusing to change ownership|could not obtain non-interactive sudo privileges' \
+        <<<"$inaccessible_output"; then
+        printf 'unexpected inaccessible data-root error:\n%s\n' "$inaccessible_output" >&2
+        exit 1
+    fi
 fi
 
 MOCK_STALE_MOUNT="${test_root}/data/mount" \

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -572,6 +572,25 @@ grep -Fq "ExecStopPost=-/usr/bin/fusermount3 -u -z ${migrated_data_root}/mount" 
     "$unit_capture"
 grep -Fq "workspace = \"${migrated_data_root}/mount\"" "${test_root}/etc/scorpio.toml"
 
+nested_runtime_root="${test_root}/nested-runtime"
+SCORPIO_SERVICE_USER=nobody bash "${repo_root}/install.sh" \
+    --version "$version" \
+    --release-base-url "$release_base_url" \
+    --non-interactive \
+    --overwrite-config \
+    --no-service \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://nested.example.com \
+    --lfs-url https://nested.example.com/lfs \
+    --prefix "${nested_runtime_root}/prefix" \
+    --config-dir "${nested_runtime_root}/etc" \
+    --data-root "${nested_runtime_root}/data" \
+    --workspace "${nested_runtime_root}/data/mount" \
+    --store-path "${nested_runtime_root}/data/private/store" \
+    --http-addr 127.0.0.1:2925
+test "$(stat -c '%U' "${nested_runtime_root}/data/private")" = nobody
+
 relative_root="${test_root}/relative-config"
 mkdir -p "${relative_root}/etc" "${relative_root}/data"
 cp "${test_root}/etc/scorpio.toml" "${relative_root}/etc/scorpio.toml"

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -36,11 +36,17 @@ systemctl() {
     return 0
 }
 
+findmnt() {
+    if [ -n "${MOCK_NESTED_MOUNT:-}" ]; then
+        printf '%s\n' "$MOCK_NESTED_MOUNT"
+    fi
+}
+
 usermod() {
     return 0
 }
 
-export -f install systemctl usermod
+export -f install systemctl findmnt usermod
 export unit_capture systemctl_log service_user
 
 SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
@@ -82,5 +88,27 @@ SUDO_USER=nobody bash "${repo_root}/install.sh" \
     --store-path "${test_root}/data/store" \
     --http-addr 127.0.0.1:2925
 test "$(stat -c '%U' "${test_root}/etc/scorpio.toml")" = "$service_user"
+
+nested_mount="${test_root}/data/store/external-mount"
+if MOCK_NESTED_MOUNT="$nested_mount" bash "${repo_root}/install.sh" \
+    --version "$version" \
+    --release-base-url "$release_base_url" \
+    --non-interactive \
+    --no-service \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://ignored.example.com \
+    --lfs-url https://ignored.example.com/lfs \
+    --prefix "${test_root}/prefix" \
+    --config-dir "${test_root}/etc" \
+    --data-root "${test_root}/data" \
+    --workspace "${test_root}/data/mount" \
+    --store-path "${test_root}/data/store" \
+    --http-addr 127.0.0.1:2925 >"${test_root}/nested-mount.log" 2>&1; then
+    printf 'installer accepted a nested mount during ownership migration\n' >&2
+    exit 1
+fi
+grep -Fq "refusing ownership migration across nested mount ${nested_mount}" \
+    "${test_root}/nested-mount.log"
 
 printf 'installer systemd generation and restart test passed\n'

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -215,8 +215,10 @@ if [ "$service_user" != root ]; then
     chmod 0711 "${inaccessible_root}/data"
     : >"${inaccessible_root}/data/sentinel"
     chown root:root "${inaccessible_root}/data/sentinel"
+    # The root test process must open the repository file before dropping privileges.
+    # shellcheck disable=SC2024
     if inaccessible_output="$(sudo -u "$inaccessible_user" -H env -u SUDO_USER \
-        bash "${repo_root}/install.sh" \
+        bash -s -- \
             --version "$version" \
             --release-base-url "$release_base_url" \
             --non-interactive \
@@ -232,7 +234,8 @@ if [ "$service_user" != root ]; then
             --data-root "${inaccessible_root}/data" \
             --workspace "${inaccessible_root}/data/mount" \
             --store-path "${inaccessible_root}/data/store" \
-            --http-addr 127.0.0.1:2925 2>&1)"; then
+            --http-addr 127.0.0.1:2925 \
+            < "${repo_root}/install.sh" 2>&1)"; then
         printf 'installer accepted an inaccessible nonempty data-root\n' >&2
         exit 1
     fi

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -217,6 +217,32 @@ grep -Fxq 'is-active --quiet scorpiofs.service' "$systemctl_log"
 grep -Fxq 'restart scorpiofs.service' "$systemctl_log"
 grep -Fxq "fusermount3 -u -z ${test_root}/data/mount" "$systemctl_log"
 
+inactive_root="${test_root}/inactive-service"
+mkdir -p "${inactive_root}/data"
+mock_service_active=0
+if MOCK_ACTIVE_MOUNT="${inactive_root}/data/mount" \
+    SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
+        --version "$version" \
+        --release-base-url "$release_base_url" \
+        --non-interactive \
+        --overwrite-config \
+        --no-deps \
+        --no-user-allow-other \
+        --base-url https://ignored.example.com \
+        --lfs-url https://ignored.example.com/lfs \
+        --prefix "${test_root}/prefix" \
+        --config-dir "${test_root}/etc" \
+        --data-root "${inactive_root}/data" \
+        --workspace "${inactive_root}/data/mount" \
+        --store-path "${inactive_root}/data/store" \
+        --http-addr 127.0.0.1:2925 >"${inactive_root}/install.log" 2>&1; then
+    printf 'installer accepted an active mount while the existing service was inactive\n' >&2
+    exit 1
+fi
+grep -Fq 'stop the ScorpioFS daemon, unmount this path, and retry' \
+    "${inactive_root}/install.log"
+mock_service_active=1
+
 MOCK_STALE_MOUNT="${test_root}/data/mount" \
 SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
     --version "$version" \
@@ -384,6 +410,39 @@ grep -Fxq 'start scorpiofs.service' "$systemctl_log"
 grep -Fq "ExecStopPost=-/usr/bin/fusermount3 -u -z ${migrated_data_root}/mount" \
     "$unit_capture"
 grep -Fq "workspace = \"${migrated_data_root}/mount\"" "${test_root}/etc/scorpio.toml"
+
+relative_root="${test_root}/relative-config"
+mkdir -p "${relative_root}/etc" "${relative_root}/data"
+cp "${test_root}/etc/scorpio.toml" "${relative_root}/etc/scorpio.toml"
+sed -i \
+    -e 's|^workspace = .*|workspace = "mount"|' \
+    -e 's|^store_path = .*|store_path = "store"|' \
+    -e 's|^config_file = .*|config_file = "config.toml"|' \
+    -e 's|^antares_upper_root = .*|antares_upper_root = "antares/upper"|' \
+    -e 's|^antares_cl_root = .*|antares_cl_root = "antares/cl"|' \
+    -e 's|^antares_mount_root = .*|antares_mount_root = "antares/mnt"|' \
+    -e 's|^antares_state_file = .*|antares_state_file = "antares/state.toml"|' \
+    "${relative_root}/etc/scorpio.toml"
+: >"${relative_root}/data/sentinel"
+if SCORPIO_SERVICE_USER=nobody bash "${repo_root}/install.sh" \
+    --version "$version" \
+    --release-base-url "$release_base_url" \
+    --non-interactive \
+    --overwrite-config \
+    --no-service \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://ignored.example.com \
+    --lfs-url https://ignored.example.com/lfs \
+    --prefix "${test_root}/prefix" \
+    --config-dir "${relative_root}/etc" \
+    --data-root "${relative_root}/data" \
+    --http-addr 127.0.0.1:2925 >"${relative_root}/install.log" 2>&1; then
+    printf 'installer accepted an ambiguous all-relative config migration\n' >&2
+    exit 1
+fi
+grep -Fq 'cannot safely use a nonempty data-root with an all-relative retained config' \
+    "${relative_root}/install.log"
 
 symlinked_data_root="${test_root}/data-link"
 ln -s "$migrated_data_root" "$symlinked_data_root"

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -231,7 +231,7 @@ grep -Fxq 'start scorpiofs.service' "$systemctl_log"
 grep -Fq "ExecStopPost=-/usr/bin/fusermount3 -u -z ${new_workspace}" "$unit_capture"
 
 if [ "$service_user" != root ] && \
-    sudo -u "$service_user" -H env -u SUDO_USER sudo -n -v; then
+    sudo -u "$service_user" -H env -u SUDO_USER sudo -n -v 2>/dev/null; then
     protected_root="${test_root}/protected-config"
     SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
         --version "$version" \
@@ -330,5 +330,29 @@ if MOCK_NESTED_MOUNT="$nested_mount" bash "${repo_root}/install.sh" \
 fi
 grep -Fq "refusing ownership migration across nested mount ${nested_mount}" \
     "${test_root}/nested-mount.log"
+
+: >"$systemctl_log"
+migrated_data_root="${test_root}/migrated-data"
+MOCK_ACTIVE_MOUNT="$new_workspace" \
+MOCK_STALE_AFTER_STOP="$new_workspace" \
+SCORPIO_SERVICE_USER=nobody bash "${repo_root}/install.sh" \
+    --version "$version" \
+    --release-base-url "$release_base_url" \
+    --non-interactive \
+    --overwrite-config \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://migrated.example.com \
+    --lfs-url https://migrated.example.com/lfs \
+    --prefix "${test_root}/prefix" \
+    --config-dir "${test_root}/etc" \
+    --data-root "$migrated_data_root" \
+    --http-addr 127.0.0.1:2925
+grep -Fxq 'stop scorpiofs.service' "$systemctl_log"
+grep -Fxq "fusermount3 -u -z ${new_workspace}" "$systemctl_log"
+grep -Fxq 'start scorpiofs.service' "$systemctl_log"
+grep -Fq "ExecStopPost=-/usr/bin/fusermount3 -u -z ${migrated_data_root}/mount" \
+    "$unit_capture"
+grep -Fq "workspace = \"${migrated_data_root}/mount\"" "${test_root}/etc/scorpio.toml"
 
 printf 'installer systemd generation and restart test passed\n'

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -101,11 +101,23 @@ umount() {
     return 0
 }
 
+curl() {
+    local arg
+    for arg in "$@"; do
+        if [[ "$arg" == */health ]]; then
+            [ "${MOCK_HEALTH_FAIL:-0}" -eq 0 ] || return 7
+            printf 'ok\n'
+            return 0
+        fi
+    done
+    command curl "$@"
+}
+
 usermod() {
     return 0
 }
 
-export -f install systemctl findmnt stat fusermount3 umount usermod
+export -f install systemctl findmnt stat fusermount3 umount usermod curl
 export unit_capture systemctl_log service_user mock_service_active mock_stale_detached
 
 non_fuse_root="${test_root}/non-fuse"
@@ -234,6 +246,28 @@ grep -Fxq 'enable scorpiofs.service' "$systemctl_log"
 grep -Fxq 'is-active --quiet scorpiofs.service' "$systemctl_log"
 grep -Fxq 'restart scorpiofs.service' "$systemctl_log"
 grep -Fxq "fusermount3 -u -z ${test_root}/data/mount" "$systemctl_log"
+: >"$systemctl_log"
+
+if MOCK_HEALTH_FAIL=1 SCORPIO_SERVICE_USER=nobody bash "${repo_root}/install.sh" \
+    --version "$version" \
+    --release-base-url "$release_base_url" \
+    --non-interactive \
+    --overwrite-config \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://unhealthy.example.com \
+    --lfs-url https://unhealthy.example.com/lfs \
+    --prefix "${test_root}/prefix" \
+    --config-dir "${test_root}/etc" \
+    --data-root "${test_root}/data" \
+    --workspace "${test_root}/data/mount" \
+    --store-path "${test_root}/data/store" \
+    --http-addr 127.0.0.1:2925 >"${test_root}/health-failure.log" 2>&1; then
+    printf 'installer accepted a service that failed its health check\n' >&2
+    exit 1
+fi
+grep -Fq 'did not become healthy' "${test_root}/health-failure.log"
+test "$(grep -Fc 'start scorpiofs.service' "$systemctl_log")" -ge 2
 : >"$systemctl_log"
 
 inactive_root="${test_root}/inactive-service"
@@ -367,6 +401,7 @@ grep -Fxq 'start scorpiofs.service' "$systemctl_log"
 grep -Fxq 'User=nobody' "$unit_capture"
 test "$(stat -c '%U' "${test_root}/etc/scorpio.toml")" = nobody
 
+chmod 0700 "${test_root}/data/store"
 SUDO_USER=daemon bash "${repo_root}/install.sh" \
     --version "$version" \
     --release-base-url "$release_base_url" \
@@ -383,6 +418,7 @@ SUDO_USER=daemon bash "${repo_root}/install.sh" \
     --store-path "${test_root}/data/store" \
     --http-addr 127.0.0.1:2925
 test "$(stat -c '%U' "${test_root}/etc/scorpio.toml")" = nobody
+test "$(stat -c '%a' "${test_root}/data/store")" = 700
 
 nested_mount="${test_root}/data/store/external-mount"
 if MOCK_NESTED_MOUNT="$nested_mount" bash "${repo_root}/install.sh" \

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -102,9 +102,11 @@ umount() {
 }
 
 curl() {
-    local arg
+    local arg saw_noproxy=0
     for arg in "$@"; do
+        [ "$arg" = "--noproxy" ] && saw_noproxy=1
         if [[ "$arg" == */health ]]; then
+            [ "$saw_noproxy" -eq 1 ] || return 64
             [ "${MOCK_HEALTH_FAIL:-0}" -eq 0 ] || return 7
             printf 'ok\n'
             return 0
@@ -221,6 +223,27 @@ SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
     --store-path "${test_root}/data/store" \
     --http-addr 127.0.0.1:2925
 
+cp "${test_root}/prefix/bin/scorpio" "${test_root}/installed-scorpio"
+rm -f "${test_root}/prefix/bin/scorpio"
+printf '#!/usr/bin/env bash\nexit 64\n' >"${test_root}/prefix/bin/scorpio"
+chmod 0755 "${test_root}/prefix/bin/scorpio"
+SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
+    --version "$version" \
+    --release-base-url "$release_base_url" \
+    --non-interactive \
+    --dry-run \
+    --no-service \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://ignored.example.com \
+    --lfs-url https://ignored.example.com/lfs \
+    --prefix "${test_root}/prefix" \
+    --config-dir "${test_root}/etc" \
+    --http-addr 127.0.0.1:2925 >"${test_root}/old-binary-dry-run.log"
+grep -Fq "using runtime paths from retained ${test_root}/etc/scorpio.toml" \
+    "${test_root}/old-binary-dry-run.log"
+mv "${test_root}/installed-scorpio" "${test_root}/prefix/bin/scorpio"
+
 antares_job_mount="${test_root}/data/antares/mnt/job-1"
 MOCK_STALE_MOUNT="$antares_job_mount" \
 SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
@@ -248,6 +271,10 @@ grep -Fxq 'restart scorpiofs.service' "$systemctl_log"
 grep -Fxq "fusermount3 -u -z ${test_root}/data/mount" "$systemctl_log"
 : >"$systemctl_log"
 
+cp "${test_root}/prefix/bin/scorpio" "${test_root}/marked-scorpio"
+printf 'old-binary-marker' >>"${test_root}/marked-scorpio"
+mv "${test_root}/marked-scorpio" "${test_root}/prefix/bin/scorpio"
+cp "${test_root}/etc/scorpio.toml" "${test_root}/config-before-health-failure.toml"
 if MOCK_HEALTH_FAIL=1 SCORPIO_SERVICE_USER=nobody bash "${repo_root}/install.sh" \
     --version "$version" \
     --release-base-url "$release_base_url" \
@@ -267,8 +294,35 @@ if MOCK_HEALTH_FAIL=1 SCORPIO_SERVICE_USER=nobody bash "${repo_root}/install.sh"
     exit 1
 fi
 grep -Fq 'did not become healthy' "${test_root}/health-failure.log"
+grep -Fq 'restoring ScorpioFS artifacts from before the failed upgrade' \
+    "${test_root}/health-failure.log"
+cmp "${test_root}/config-before-health-failure.toml" "${test_root}/etc/scorpio.toml"
+tail -c 17 "${test_root}/prefix/bin/scorpio" | grep -Fxq 'old-binary-marker'
 test "$(grep -Fc 'start scorpiofs.service' "$systemctl_log")" -ge 2
 : >"$systemctl_log"
+
+sed -i 's/^User=.*/User=root/' "$unit_capture"
+chmod 0750 "${test_root}/etc"
+if SCORPIO_SERVICE_USER=nobody bash "${repo_root}/install.sh" \
+    --version "$version" \
+    --release-base-url "$release_base_url" \
+    --non-interactive \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://ignored.example.com \
+    --lfs-url https://ignored.example.com/lfs \
+    --prefix "${test_root}/prefix" \
+    --config-dir "${test_root}/etc" \
+    --http-addr 127.0.0.1:2925 >"${test_root}/config-traversal.log" 2>&1; then
+    printf 'installer accepted a config directory inaccessible to the new service user\n' >&2
+    exit 1
+fi
+grep -Fq 'cannot traverse config-dir' "${test_root}/config-traversal.log"
+if grep -Fxq 'stop scorpiofs.service' "$systemctl_log"; then
+    printf 'installer stopped the service before validating config traversal\n' >&2
+    exit 1
+fi
+chmod 0755 "${test_root}/etc"
 
 inactive_root="${test_root}/inactive-service"
 mkdir -p "${inactive_root}/data"

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -162,6 +162,36 @@ grep -Fq 'stop the ScorpioFS daemon, unmount this path, and retry' \
 test ! -e "${unmanaged_root}/prefix/bin/scorpio"
 : >"$systemctl_log"
 
+if [ "$service_user" != root ]; then
+    inaccessible_root="${test_root}/inaccessible-data"
+    mkdir -p "${inaccessible_root}/etc" "${inaccessible_root}/data"
+    chown "$service_user" "${inaccessible_root}/etc"
+    chmod 0711 "${inaccessible_root}/data"
+    : >"${inaccessible_root}/data/sentinel"
+    chown root:root "${inaccessible_root}/data/sentinel"
+    if inaccessible_output="$(sudo -u "$service_user" -H env -u SUDO_USER \
+        bash "${repo_root}/install.sh" \
+            --version "$version" \
+            --release-base-url "$release_base_url" \
+            --non-interactive \
+            --overwrite-config \
+            --no-service \
+            --no-deps \
+            --no-user-allow-other \
+            --base-url https://mega.example.com \
+            --lfs-url https://mega.example.com/lfs \
+            --prefix "${inaccessible_root}/prefix" \
+            --config-dir "${inaccessible_root}/etc" \
+            --data-root "${inaccessible_root}/data" \
+            --workspace "${inaccessible_root}/data/mount" \
+            --store-path "${inaccessible_root}/data/store" \
+            --http-addr 127.0.0.1:2925 2>&1)"; then
+        printf 'installer accepted an inaccessible nonempty data-root\n' >&2
+        exit 1
+    fi
+    grep -Fq 'could not inspect data-root; refusing to change ownership' <<<"$inaccessible_output"
+fi
+
 MOCK_STALE_MOUNT="${test_root}/data/mount" \
 SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
     --version "$version" \
@@ -180,7 +210,7 @@ SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
     --http-addr 127.0.0.1:2925
 
 grep -Fq 'ExecStopPost=-/bin/sh -c' "$unit_capture"
-grep -Fq -- "--submounts ${test_root}/data/antares/mnt" "$unit_capture"
+grep -Fq 'findmnt -rno TARGET 2>/dev/null | sort -r' "$unit_capture"
 grep -Fq "ExecStopPost=-/usr/bin/fusermount3 -u -z ${test_root}/data/mount" "$unit_capture"
 grep -Fxq 'enable scorpiofs.service' "$systemctl_log"
 grep -Fxq 'is-active --quiet scorpiofs.service' "$systemctl_log"

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -30,6 +30,9 @@ install() {
 
 systemctl() {
     printf '%s\n' "$*" >>"$systemctl_log"
+    if [ "${1:-}" = "show" ]; then
+        printf '%s\n' "$service_user"
+    fi
     return 0
 }
 
@@ -38,7 +41,7 @@ usermod() {
 }
 
 export -f install systemctl usermod
-export unit_capture systemctl_log
+export unit_capture systemctl_log service_user
 
 SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
     --version "$version" \
@@ -62,5 +65,22 @@ grep -Fq "ExecStopPost=-/usr/bin/fusermount3 -u -z ${test_root}/data/mount" "$un
 grep -Fxq 'enable scorpiofs.service' "$systemctl_log"
 grep -Fxq 'is-active --quiet scorpiofs.service' "$systemctl_log"
 grep -Fxq 'restart scorpiofs.service' "$systemctl_log"
+
+SUDO_USER=nobody bash "${repo_root}/install.sh" \
+    --version "$version" \
+    --release-base-url "$release_base_url" \
+    --non-interactive \
+    --no-service \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://ignored.example.com \
+    --lfs-url https://ignored.example.com/lfs \
+    --prefix "${test_root}/prefix" \
+    --config-dir "${test_root}/etc" \
+    --data-root "${test_root}/data" \
+    --workspace "${test_root}/data/mount" \
+    --store-path "${test_root}/data/store" \
+    --http-addr 127.0.0.1:2925
+test "$(stat -c '%U' "${test_root}/etc/scorpio.toml")" = "$service_user"
 
 printf 'installer systemd generation and restart test passed\n'

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+    printf 'usage: %s <version> <release-base-url> <test-root>\n' "$0" >&2
+    exit 2
+fi
+[ "$(id -u)" -eq 0 ] || { printf 'this test must run as root\n' >&2; exit 2; }
+
+version="$1"
+release_base_url="$2"
+test_root="$3"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+service_user="${SUDO_USER:-root}"
+unit_capture="${test_root}/scorpiofs.service"
+systemctl_log="${test_root}/systemctl.log"
+
+mkdir -p "$test_root"
+: >"$systemctl_log"
+
+install() {
+    local destination="${*: -1}"
+    if [ "$destination" = "/etc/systemd/system/scorpiofs.service" ]; then
+        local source="${*: -2:1}"
+        command cp "$source" "$unit_capture"
+    else
+        command /usr/bin/install "$@"
+    fi
+}
+
+systemctl() {
+    printf '%s\n' "$*" >>"$systemctl_log"
+    return 0
+}
+
+usermod() {
+    return 0
+}
+
+export -f install systemctl usermod
+export unit_capture systemctl_log
+
+SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
+    --version "$version" \
+    --release-base-url "$release_base_url" \
+    --non-interactive \
+    --overwrite-config \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://mega.example.com \
+    --lfs-url https://mega.example.com/lfs \
+    --prefix "${test_root}/prefix" \
+    --config-dir "${test_root}/etc" \
+    --data-root "${test_root}/data" \
+    --workspace "${test_root}/data/mount" \
+    --store-path "${test_root}/data/store" \
+    --http-addr 127.0.0.1:2925
+
+grep -Fq 'ExecStopPost=-/bin/sh -c' "$unit_capture"
+grep -Fq -- "--submounts ${test_root}/data/antares/mnt" "$unit_capture"
+grep -Fq "ExecStopPost=-/usr/bin/fusermount3 -u -z ${test_root}/data/mount" "$unit_capture"
+grep -Fxq 'enable scorpiofs.service' "$systemctl_log"
+grep -Fxq 'is-active --quiet scorpiofs.service' "$systemctl_log"
+grep -Fxq 'restart scorpiofs.service' "$systemctl_log"
+
+printf 'installer systemd generation and restart test passed\n'

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -122,6 +122,24 @@ usermod() {
 export -f install systemctl findmnt stat fusermount3 umount usermod curl
 export unit_capture systemctl_log service_user mock_service_active mock_stale_detached
 
+assert_systemctl_log_line() {
+    local expected="$1"
+    if ! grep -Fxq "$expected" "$systemctl_log"; then
+        printf 'missing systemctl mock log entry: %s\nactual log:\n' "$expected" >&2
+        cat "$systemctl_log" >&2
+        exit 1
+    fi
+}
+
+assert_unit_contains() {
+    local expected="$1"
+    if ! grep -Fq "$expected" "$unit_capture"; then
+        printf 'missing generated unit entry: %s\nactual unit:\n' "$expected" >&2
+        cat "$unit_capture" >&2
+        exit 1
+    fi
+}
+
 non_fuse_root="${test_root}/non-fuse"
 mkdir -p "$non_fuse_root"
 if MOCK_STALE_MOUNT="${non_fuse_root}/data/mount" MOCK_MOUNT_FSTYPE=nfs \
@@ -260,15 +278,15 @@ SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
     --workspace "${test_root}/data/mount" \
     --store-path "${test_root}/data/store" \
     --http-addr 127.0.0.1:2925 >"${test_root}/antares-child-mount.log"
-grep -Fxq "fusermount3 -u -z ${antares_job_mount}" "$systemctl_log"
+assert_systemctl_log_line "fusermount3 -u -z ${antares_job_mount}"
 
-grep -Fq 'ExecStopPost=-/bin/sh -c' "$unit_capture"
-grep -Fq 'findmnt -rno TARGET 2>/dev/null | sort -r' "$unit_capture"
-grep -Fq "ExecStopPost=-/usr/bin/fusermount3 -u -z ${test_root}/data/mount" "$unit_capture"
-grep -Fxq 'enable scorpiofs.service' "$systemctl_log"
-grep -Fxq 'is-active --quiet scorpiofs.service' "$systemctl_log"
-grep -Fxq 'restart scorpiofs.service' "$systemctl_log"
-grep -Fxq "fusermount3 -u -z ${test_root}/data/mount" "$systemctl_log"
+assert_unit_contains 'ExecStopPost=-/bin/sh -c'
+assert_unit_contains 'findmnt -rno TARGET 2>/dev/null | sort -r'
+assert_unit_contains "ExecStopPost=-/usr/bin/fusermount3 -u -z ${test_root}/data/mount"
+assert_systemctl_log_line 'enable scorpiofs.service'
+assert_systemctl_log_line 'is-active --quiet scorpiofs.service'
+assert_systemctl_log_line 'restart scorpiofs.service'
+assert_systemctl_log_line "fusermount3 -u -z ${test_root}/data/mount"
 : >"$systemctl_log"
 
 cp "${test_root}/prefix/bin/scorpio" "${test_root}/marked-scorpio"

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -14,6 +14,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 service_user="${SUDO_USER:-root}"
 unit_capture="${test_root}/scorpiofs.service"
 systemctl_log="${test_root}/systemctl.log"
+mock_service_active=1
 
 mkdir -p "$test_root"
 : >"$systemctl_log"
@@ -30,10 +31,17 @@ install() {
 
 systemctl() {
     printf '%s\n' "$*" >>"$systemctl_log"
-    if [ "${1:-}" = "show" ]; then
-        printf '%s\n' "$service_user"
-    fi
-    return 0
+    case "${1:-}" in
+        show)
+            if [ -r "$unit_capture" ]; then
+                awk -F= '$1 == "User" { print $2; exit }' "$unit_capture"
+            fi
+            ;;
+        is-active) [ "$mock_service_active" -eq 1 ] ;;
+        stop) mock_service_active=0 ;;
+        start|restart) mock_service_active=1 ;;
+        *) return 0 ;;
+    esac
 }
 
 findmnt() {
@@ -47,7 +55,7 @@ usermod() {
 }
 
 export -f install systemctl findmnt usermod
-export unit_capture systemctl_log service_user
+export unit_capture systemctl_log service_user mock_service_active
 
 SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
     --version "$version" \
@@ -72,7 +80,26 @@ grep -Fxq 'enable scorpiofs.service' "$systemctl_log"
 grep -Fxq 'is-active --quiet scorpiofs.service' "$systemctl_log"
 grep -Fxq 'restart scorpiofs.service' "$systemctl_log"
 
-SUDO_USER=nobody bash "${repo_root}/install.sh" \
+SCORPIO_SERVICE_USER=nobody bash "${repo_root}/install.sh" \
+    --version "$version" \
+    --release-base-url "$release_base_url" \
+    --non-interactive \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://ignored.example.com \
+    --lfs-url https://ignored.example.com/lfs \
+    --prefix "${test_root}/prefix" \
+    --config-dir "${test_root}/etc" \
+    --data-root "${test_root}/data" \
+    --workspace "${test_root}/data/mount" \
+    --store-path "${test_root}/data/store" \
+    --http-addr 127.0.0.1:2925
+grep -Fxq 'stop scorpiofs.service' "$systemctl_log"
+grep -Fxq 'start scorpiofs.service' "$systemctl_log"
+grep -Fxq 'User=nobody' "$unit_capture"
+test "$(stat -c '%U' "${test_root}/etc/scorpio.toml")" = nobody
+
+SUDO_USER=daemon bash "${repo_root}/install.sh" \
     --version "$version" \
     --release-base-url "$release_base_url" \
     --non-interactive \
@@ -87,7 +114,7 @@ SUDO_USER=nobody bash "${repo_root}/install.sh" \
     --workspace "${test_root}/data/mount" \
     --store-path "${test_root}/data/store" \
     --http-addr 127.0.0.1:2925
-test "$(stat -c '%U' "${test_root}/etc/scorpio.toml")" = "$service_user"
+test "$(stat -c '%U' "${test_root}/etc/scorpio.toml")" = nobody
 
 nested_mount="${test_root}/data/store/external-mount"
 if MOCK_NESTED_MOUNT="$nested_mount" bash "${repo_root}/install.sh" \

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -15,6 +15,7 @@ service_user="${SUDO_USER:-root}"
 unit_capture="${test_root}/scorpiofs.service"
 systemctl_log="${test_root}/systemctl.log"
 mock_service_active=1
+mock_stale_detached=0
 
 mkdir -p "$test_root"
 : >"$systemctl_log"
@@ -45,8 +46,26 @@ systemctl() {
 }
 
 findmnt() {
+    if [ -n "${MOCK_STALE_MOUNT:-}" ] && [ "$mock_stale_detached" -eq 0 ]; then
+        printf '%s\n' "$MOCK_STALE_MOUNT"
+    fi
     if [ -n "${MOCK_NESTED_MOUNT:-}" ]; then
         printf '%s\n' "$MOCK_NESTED_MOUNT"
+    fi
+}
+
+stat() {
+    if [ -n "${MOCK_STALE_MOUNT:-}" ] && [ "${*: -1}" = "$MOCK_STALE_MOUNT" ] && \
+        [ "$mock_stale_detached" -eq 0 ]; then
+        return 1
+    fi
+    command /usr/bin/stat "$@"
+}
+
+fusermount3() {
+    printf 'fusermount3 %s\n' "$*" >>"$systemctl_log"
+    if [ -n "${MOCK_STALE_MOUNT:-}" ] && [ "${*: -1}" = "$MOCK_STALE_MOUNT" ]; then
+        mock_stale_detached=1
     fi
 }
 
@@ -54,9 +73,10 @@ usermod() {
     return 0
 }
 
-export -f install systemctl findmnt usermod
-export unit_capture systemctl_log service_user mock_service_active
+export -f install systemctl findmnt stat fusermount3 usermod
+export unit_capture systemctl_log service_user mock_service_active mock_stale_detached
 
+MOCK_STALE_MOUNT="${test_root}/data/mount" \
 SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
     --version "$version" \
     --release-base-url "$release_base_url" \
@@ -79,6 +99,7 @@ grep -Fq "ExecStopPost=-/usr/bin/fusermount3 -u -z ${test_root}/data/mount" "$un
 grep -Fxq 'enable scorpiofs.service' "$systemctl_log"
 grep -Fxq 'is-active --quiet scorpiofs.service' "$systemctl_log"
 grep -Fxq 'restart scorpiofs.service' "$systemctl_log"
+grep -Fxq "fusermount3 -u -z ${test_root}/data/mount" "$systemctl_log"
 
 SCORPIO_SERVICE_USER=nobody bash "${repo_root}/install.sh" \
     --version "$version" \

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -298,6 +298,9 @@ grep -Fq 'restoring ScorpioFS artifacts from before the failed upgrade' \
     "${test_root}/health-failure.log"
 cmp "${test_root}/config-before-health-failure.toml" "${test_root}/etc/scorpio.toml"
 tail -c 17 "${test_root}/prefix/bin/scorpio" | grep -Fxq 'old-binary-marker'
+test "$(stat -c '%U' "${test_root}/data/store")" = "$service_user"
+test "$(stat -c '%U' "${test_root}/data/antares/upper")" = "$service_user"
+test "$(stat -c '%U' "${test_root}/data/antares/cl")" = "$service_user"
 test "$(grep -Fc 'start scorpiofs.service' "$systemctl_log")" -ge 2
 : >"$systemctl_log"
 

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -206,6 +206,7 @@ if [ "$service_user" != root ]; then
             --version "$version" \
             --release-base-url "$release_base_url" \
             --non-interactive \
+            --dry-run \
             --overwrite-config \
             --no-service \
             --no-deps \
@@ -323,6 +324,8 @@ tail -c 17 "${test_root}/prefix/bin/scorpio" | grep -Fxq 'old-binary-marker'
 test "$(stat -c '%U' "${test_root}/data/store")" = "$service_user"
 test "$(stat -c '%U' "${test_root}/data/antares/upper")" = "$service_user"
 test "$(stat -c '%U' "${test_root}/data/antares/cl")" = "$service_user"
+test "$(stat -c '%U' "${test_root}/data")" = "$service_user"
+grep -Fxq 'stop scorpiofs.service' "$systemctl_log"
 test "$(grep -Fc 'start scorpiofs.service' "$systemctl_log")" -ge 2
 : >"$systemctl_log"
 
@@ -600,6 +603,28 @@ if SCORPIO_SERVICE_USER=nobody bash "${repo_root}/install.sh" \
 fi
 grep -Fq 'cannot safely use a nonempty data-root with an all-relative retained config' \
     "${relative_root}/install.log"
+
+relative_empty_root="${test_root}/relative-empty"
+mkdir -p "${relative_empty_root}/etc" "${relative_empty_root}/data"
+cp "${relative_root}/etc/scorpio.toml" "${relative_empty_root}/etc/scorpio.toml"
+if SCORPIO_SERVICE_USER=nobody bash "${repo_root}/install.sh" \
+    --version "$version" \
+    --release-base-url "$release_base_url" \
+    --non-interactive \
+    --no-service \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://ignored.example.com \
+    --lfs-url https://ignored.example.com/lfs \
+    --prefix "${test_root}/prefix" \
+    --config-dir "${relative_empty_root}/etc" \
+    --data-root "${relative_empty_root}/data" \
+    --http-addr 127.0.0.1:2925 >"${relative_empty_root}/install.log" 2>&1; then
+    printf 'installer accepted an empty data-root with an all-relative retained config\n' >&2
+    exit 1
+fi
+grep -Fq 'cannot safely use an empty data-root with an all-relative retained config' \
+    "${relative_empty_root}/install.log"
 
 symlinked_data_root="${test_root}/data-link"
 ln -s "$migrated_data_root" "$symlinked_data_root"

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -209,6 +209,24 @@ SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
     --store-path "${test_root}/data/store" \
     --http-addr 127.0.0.1:2925
 
+antares_job_mount="${test_root}/data/antares/mnt/job-1"
+MOCK_STALE_MOUNT="$antares_job_mount" \
+SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
+    --version "$version" \
+    --release-base-url "$release_base_url" \
+    --non-interactive \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://ignored.example.com \
+    --lfs-url https://ignored.example.com/lfs \
+    --prefix "${test_root}/prefix" \
+    --config-dir "${test_root}/etc" \
+    --data-root "${test_root}/data" \
+    --workspace "${test_root}/data/mount" \
+    --store-path "${test_root}/data/store" \
+    --http-addr 127.0.0.1:2925 >"${test_root}/antares-child-mount.log"
+grep -Fxq "fusermount3 -u -z ${antares_job_mount}" "$systemctl_log"
+
 grep -Fq 'ExecStopPost=-/bin/sh -c' "$unit_capture"
 grep -Fq 'findmnt -rno TARGET 2>/dev/null | sort -r' "$unit_capture"
 grep -Fq "ExecStopPost=-/usr/bin/fusermount3 -u -z ${test_root}/data/mount" "$unit_capture"
@@ -216,6 +234,7 @@ grep -Fxq 'enable scorpiofs.service' "$systemctl_log"
 grep -Fxq 'is-active --quiet scorpiofs.service' "$systemctl_log"
 grep -Fxq 'restart scorpiofs.service' "$systemctl_log"
 grep -Fxq "fusermount3 -u -z ${test_root}/data/mount" "$systemctl_log"
+: >"$systemctl_log"
 
 inactive_root="${test_root}/inactive-service"
 mkdir -p "${inactive_root}/data"
@@ -386,6 +405,29 @@ if MOCK_NESTED_MOUNT="$nested_mount" bash "${repo_root}/install.sh" \
 fi
 grep -Fq "refusing ownership migration across nested mount ${nested_mount}" \
     "${test_root}/nested-mount.log"
+
+runtime_mount="${test_root}/data/store"
+if MOCK_NESTED_MOUNT="$runtime_mount" SCORPIO_SERVICE_USER=nobody \
+    bash "${repo_root}/install.sh" \
+        --version "$version" \
+        --release-base-url "$release_base_url" \
+        --non-interactive \
+        --no-service \
+        --no-deps \
+        --no-user-allow-other \
+        --base-url https://ignored.example.com \
+        --lfs-url https://ignored.example.com/lfs \
+        --prefix "${test_root}/prefix" \
+        --config-dir "${test_root}/etc" \
+        --data-root "${test_root}/data" \
+        --workspace "${test_root}/data/mount" \
+        --store-path "${test_root}/data/store" \
+        --http-addr 127.0.0.1:2925 >"${test_root}/runtime-root-mount.log" 2>&1; then
+    printf 'installer accepted a mount at a persistent runtime root\n' >&2
+    exit 1
+fi
+grep -Fq "refusing ownership migration across mount ${runtime_mount} at runtime directory" \
+    "${test_root}/runtime-root-mount.log"
 
 : >"$systemctl_log"
 migrated_data_root="${test_root}/migrated-data"

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -39,18 +39,42 @@ systemctl() {
             fi
             ;;
         is-active) [ "$mock_service_active" -eq 1 ] ;;
-        stop) mock_service_active=0 ;;
+        stop)
+            mock_service_active=0
+            if [ -n "${MOCK_STALE_AFTER_STOP:-}" ]; then
+                MOCK_ACTIVE_MOUNT=""
+                MOCK_STALE_MOUNT="$MOCK_STALE_AFTER_STOP"
+                mock_stale_detached=0
+            fi
+            ;;
         start|restart) mock_service_active=1 ;;
         *) return 0 ;;
     esac
 }
 
 findmnt() {
+    local include_fstype=0 fstype="${MOCK_MOUNT_FSTYPE:-fuse.scorpiofs}"
+    case " $* " in *' TARGET,FSTYPE '*) include_fstype=1 ;; esac
     if [ -n "${MOCK_STALE_MOUNT:-}" ] && [ "$mock_stale_detached" -eq 0 ]; then
-        printf '%s\n' "$MOCK_STALE_MOUNT"
+        if [ "$include_fstype" -eq 1 ]; then
+            printf '%s %s\n' "$MOCK_STALE_MOUNT" "$fstype"
+        else
+            printf '%s\n' "$MOCK_STALE_MOUNT"
+        fi
+    fi
+    if [ -n "${MOCK_ACTIVE_MOUNT:-}" ]; then
+        if [ "$include_fstype" -eq 1 ]; then
+            printf '%s %s\n' "$MOCK_ACTIVE_MOUNT" "$fstype"
+        else
+            printf '%s\n' "$MOCK_ACTIVE_MOUNT"
+        fi
     fi
     if [ -n "${MOCK_NESTED_MOUNT:-}" ]; then
-        printf '%s\n' "$MOCK_NESTED_MOUNT"
+        if [ "$include_fstype" -eq 1 ]; then
+            printf '%s ext4\n' "$MOCK_NESTED_MOUNT"
+        else
+            printf '%s\n' "$MOCK_NESTED_MOUNT"
+        fi
     fi
 }
 
@@ -58,6 +82,9 @@ stat() {
     if [ -n "${MOCK_STALE_MOUNT:-}" ] && [ "${*: -1}" = "$MOCK_STALE_MOUNT" ] && \
         [ "$mock_stale_detached" -eq 0 ]; then
         return 1
+    fi
+    if [ -n "${MOCK_ACTIVE_MOUNT:-}" ] && [ "${*: -1}" = "$MOCK_ACTIVE_MOUNT" ]; then
+        return 0
     fi
     command /usr/bin/stat "$@"
 }
@@ -69,12 +96,71 @@ fusermount3() {
     fi
 }
 
+umount() {
+    printf 'umount %s\n' "$*" >>"$systemctl_log"
+    return 0
+}
+
 usermod() {
     return 0
 }
 
-export -f install systemctl findmnt stat fusermount3 usermod
+export -f install systemctl findmnt stat fusermount3 umount usermod
 export unit_capture systemctl_log service_user mock_service_active mock_stale_detached
+
+non_fuse_root="${test_root}/non-fuse"
+mkdir -p "$non_fuse_root"
+if MOCK_STALE_MOUNT="${non_fuse_root}/data/mount" MOCK_MOUNT_FSTYPE=nfs \
+    SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
+        --version "$version" \
+        --release-base-url "$release_base_url" \
+        --non-interactive \
+        --overwrite-config \
+        --no-deps \
+        --no-user-allow-other \
+        --base-url https://mega.example.com \
+        --lfs-url https://mega.example.com/lfs \
+        --prefix "${non_fuse_root}/prefix" \
+        --config-dir "${non_fuse_root}/etc" \
+        --data-root "${non_fuse_root}/data" \
+        --workspace "${non_fuse_root}/data/mount" \
+        --store-path "${non_fuse_root}/data/store" \
+        --http-addr 127.0.0.1:2925 >"${non_fuse_root}/install.log" 2>&1; then
+    printf 'installer detached a non-FUSE mount\n' >&2
+    exit 1
+fi
+grep -Fq 'mounted with non-FUSE filesystem type nfs' "${non_fuse_root}/install.log"
+if grep -Eq '^(fusermount3|umount) ' "$systemctl_log"; then
+    printf 'installer invoked an unmount helper for a non-FUSE mount\n' >&2
+    exit 1
+fi
+test ! -e "${non_fuse_root}/prefix/bin/scorpio"
+
+unmanaged_root="${test_root}/unmanaged"
+mkdir -p "$unmanaged_root"
+if MOCK_ACTIVE_MOUNT="${unmanaged_root}/data/mount" \
+    SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
+        --version "$version" \
+        --release-base-url "$release_base_url" \
+        --non-interactive \
+        --overwrite-config \
+        --no-deps \
+        --no-user-allow-other \
+        --base-url https://mega.example.com \
+        --lfs-url https://mega.example.com/lfs \
+        --prefix "${unmanaged_root}/prefix" \
+        --config-dir "${unmanaged_root}/etc" \
+        --data-root "${unmanaged_root}/data" \
+        --workspace "${unmanaged_root}/data/mount" \
+        --store-path "${unmanaged_root}/data/store" \
+        --http-addr 127.0.0.1:2925 >"${unmanaged_root}/install.log" 2>&1; then
+    printf 'installer accepted an unmanaged active FUSE mount\n' >&2
+    exit 1
+fi
+grep -Fq 'stop the ScorpioFS daemon, unmount this path, and retry' \
+    "${unmanaged_root}/install.log"
+test ! -e "${unmanaged_root}/prefix/bin/scorpio"
+: >"$systemctl_log"
 
 MOCK_STALE_MOUNT="${test_root}/data/mount" \
 SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
@@ -100,6 +186,30 @@ grep -Fxq 'enable scorpiofs.service' "$systemctl_log"
 grep -Fxq 'is-active --quiet scorpiofs.service' "$systemctl_log"
 grep -Fxq 'restart scorpiofs.service' "$systemctl_log"
 grep -Fxq "fusermount3 -u -z ${test_root}/data/mount" "$systemctl_log"
+
+: >"$systemctl_log"
+new_workspace="${test_root}/data/mount-new"
+MOCK_ACTIVE_MOUNT="${test_root}/data/mount" \
+MOCK_STALE_AFTER_STOP="${test_root}/data/mount" \
+SCORPIO_SERVICE_USER="$service_user" bash "${repo_root}/install.sh" \
+    --version "$version" \
+    --release-base-url "$release_base_url" \
+    --non-interactive \
+    --overwrite-config \
+    --no-deps \
+    --no-user-allow-other \
+    --base-url https://mega.example.com \
+    --lfs-url https://mega.example.com/lfs \
+    --prefix "${test_root}/prefix" \
+    --config-dir "${test_root}/etc" \
+    --data-root "${test_root}/data" \
+    --workspace "$new_workspace" \
+    --store-path "${test_root}/data/store" \
+    --http-addr 127.0.0.1:2925
+grep -Fxq 'stop scorpiofs.service' "$systemctl_log"
+grep -Fxq "fusermount3 -u -z ${test_root}/data/mount" "$systemctl_log"
+grep -Fxq 'start scorpiofs.service' "$systemctl_log"
+grep -Fq "ExecStopPost=-/usr/bin/fusermount3 -u -z ${new_workspace}" "$unit_capture"
 
 SCORPIO_SERVICE_USER=nobody bash "${repo_root}/install.sh" \
     --version "$version" \

--- a/script/test_installer_systemd.sh
+++ b/script/test_installer_systemd.sh
@@ -20,6 +20,19 @@ mock_stale_detached=0
 mkdir -p "$test_root"
 : >"$systemctl_log"
 
+report_test_failure() {
+    local status=$?
+    printf 'installer systemd test failed at line %s: %s\n' \
+        "${BASH_LINENO[0]}" "$BASH_COMMAND" >&2
+    for log in "$test_root"/*/install.log "$test_root"/*.log; do
+        [ -f "$log" ] || continue
+        printf '%s:\n' "$log" >&2
+        tail -20 "$log" >&2
+    done
+    exit "$status"
+}
+trap report_test_failure ERR
+
 install() {
     local destination="${*: -1}"
     if [ "$destination" = "/etc/systemd/system/scorpiofs.service" ]; then

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,13 @@
 //! HTTP.
 
 use std::{
-    collections::HashMap, ffi::OsStr, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration,
+    collections::HashMap,
+    ffi::OsStr,
+    io::{self, Write},
+    net::SocketAddr,
+    path::PathBuf,
+    sync::Arc,
+    time::Duration,
 };
 
 use asyncfuse::raw::logfs::LoggingFileSystem;
@@ -351,6 +357,44 @@ pub fn config_validate(config_path: &str, overrides: HashMap<String, String>) ->
 /// [`init`] has already loaded configuration.
 pub fn config_show() -> i32 {
     println!("{}", config::effective_config_dump());
+    exit::SUCCESS
+}
+
+/// Emit effective runtime paths as NUL-delimited records for `install.sh`.
+///
+/// This deliberately avoids global config initialization because initialization
+/// creates runtime directories, which would be unsafe during installer checks.
+pub fn config_installer_paths(config_path: &str, overrides: HashMap<String, String>) -> i32 {
+    let paths = match config::resolve_runtime_paths(config_path, overrides) {
+        Ok(paths) => paths,
+        Err(e) => {
+            eprintln!("failed to resolve runtime paths from '{config_path}': {e}");
+            return exit::CONFIG;
+        }
+    };
+    let values = [
+        paths.workspace,
+        paths.store_path,
+        paths.config_file,
+        paths.antares_upper_root,
+        paths.antares_cl_root,
+        paths.antares_mount_root,
+        paths.antares_state_file,
+    ];
+    let mut stdout = io::stdout().lock();
+    for value in values {
+        if value.as_bytes().contains(&0) {
+            eprintln!("runtime path contains a NUL byte and cannot be installed");
+            return exit::CONFIG;
+        }
+        if let Err(e) = stdout
+            .write_all(value.as_bytes())
+            .and_then(|_| stdout.write_all(&[0]))
+        {
+            eprintln!("failed to write installer runtime paths: {e}");
+            return exit::INTERNAL;
+        }
+    }
     exit::SUCCESS
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,9 @@ enum ConfigAction {
     Validate,
     /// Print the effective (merged) configuration.
     Show,
+    /// Emit runtime paths for the release installer.
+    #[command(hide = true)]
+    InstallerPaths,
 }
 
 #[tokio::main]
@@ -134,6 +137,14 @@ async fn main() {
         }) => {
             std::process::exit(cli::config_validate(&cli.config_path, overrides.clone()));
         }
+        Some(Commands::Config {
+            action: ConfigAction::InstallerPaths,
+        }) => {
+            std::process::exit(cli::config_installer_paths(
+                &cli.config_path,
+                overrides.clone(),
+            ));
+        }
         _ => {}
     }
 
@@ -164,7 +175,7 @@ async fn main() {
             action: ConfigAction::Show,
         }) => cli::config_show(),
         Some(Commands::Config { .. }) => {
-            unreachable!("config init/validate handled before config init")
+            unreachable!("config init/validate/installer-paths handled before config init")
         }
         Some(Commands::Doctor) => doctor::run().await,
         Some(Commands::Completions { .. }) => unreachable!("handled before config init"),

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -49,6 +49,21 @@ pub struct ScorpioConfig {
     pub antares_state_file: String,
 }
 
+/// Filesystem paths the installer must prepare for the effective config.
+///
+/// Resolving this separately from [`init_config_with`] lets the installer
+/// validate retained configuration before making any ownership changes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimePaths {
+    pub workspace: String,
+    pub store_path: String,
+    pub config_file: String,
+    pub antares_upper_root: String,
+    pub antares_cl_root: String,
+    pub antares_mount_root: String,
+    pub antares_state_file: String,
+}
+
 const DEFAULT_LOAD_DIR_DEPTH: usize = 3;
 const DEFAULT_FETCH_FILE_THREAD: usize = 10;
 const DEFAULT_ANTARES_SUBDIR: &str = "antares";
@@ -1030,6 +1045,23 @@ pub fn effective_config_dump() -> String {
     format!("{:#?}", get_config())
 }
 
+/// Resolve runtime paths without creating directories or state files.
+pub fn resolve_runtime_paths(
+    path: &str,
+    cli_overrides: HashMap<String, String>,
+) -> ConfigResult<RuntimePaths> {
+    let cfg = parse_config(path, cli_overrides)?;
+    Ok(RuntimePaths {
+        workspace: cfg.workspace,
+        store_path: cfg.store_path,
+        config_file: cfg.config_file,
+        antares_upper_root: cfg.antares_upper_root,
+        antares_cl_root: cfg.antares_cl_root,
+        antares_mount_root: cfg.antares_mount_root,
+        antares_state_file: cfg.antares_state_file,
+    })
+}
+
 /// Create the runtime directories and ensure the state file exists.
 ///
 /// Unlike the previous implementation, this never rewrites the user's main
@@ -1100,19 +1132,20 @@ pub fn init_config_with(path: &str, cli_overrides: HashMap<String, String>) -> C
         return Err("Configuration already initialized".to_string());
     }
 
-    let content =
-        fs::read_to_string(path).map_err(|e| format!("Config file not found at '{path}': {e}"))?;
-
-    let file: toml::Table =
-        toml::from_str(&content).map_err(|e| format!("Invalid config format in '{path}': {e}"))?;
-
-    let resolver = RawResolver::new(file, cli_overrides);
-    let cfg = build_config(&resolver)?;
+    let cfg = parse_config(path, cli_overrides)?;
     ensure_runtime_paths(&cfg)?;
 
     SCORPIO_CONFIG
         .set(cfg)
         .map_err(|_| "Configuration already initialized".to_string())
+}
+
+fn parse_config(path: &str, cli_overrides: HashMap<String, String>) -> ConfigResult<ScorpioConfig> {
+    let content =
+        fs::read_to_string(path).map_err(|e| format!("Config file not found at '{path}': {e}"))?;
+    let file: toml::Table =
+        toml::from_str(&content).map_err(|e| format!("Invalid config format in '{path}': {e}"))?;
+    build_config(&RawResolver::new(file, cli_overrides))
 }
 
 /// Get reference to global configuration.
@@ -1544,5 +1577,40 @@ mod tests {
         std::fs::write(&path, ok).unwrap();
         assert!(validate_file(&path, HashMap::new()).is_ok());
         std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn resolve_runtime_paths_has_no_filesystem_side_effects() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let runtime = temp.path().join("runtime");
+        let runtime_config_value = runtime.to_string_lossy().replace('\\', "/");
+        let config_path = temp.path().join("scorpio.toml");
+        let config = format!(
+            r#"
+            base_url = "http://example.com"
+            lfs_url = "http://example.com/lfs"
+            workspace = "{0}/mount"
+            store_path = "{0}/store"
+            config_file = "{0}/state/config.toml"
+            antares_upper_root = "{0}/antares/upper"
+            antares_cl_root = "{0}/antares/cl"
+            antares_mount_root = "{0}/antares/mnt"
+            antares_state_file = "{0}/antares/state.toml"
+            "#,
+            runtime_config_value
+        );
+        std::fs::write(&config_path, config).expect("write config");
+
+        let paths = resolve_runtime_paths(
+            config_path.to_str().expect("UTF-8 config path"),
+            HashMap::new(),
+        )
+        .expect("resolve runtime paths");
+
+        assert_eq!(paths.workspace, format!("{runtime_config_value}/mount"));
+        assert!(
+            !runtime.exists(),
+            "path resolution must not create runtime data"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add an interactive one-command installer for backend URLs, local paths, FUSE permissions, and systemd setup.
- Verify release SHA256 and binary compatibility before replacing installed binaries.
- Validate URLs, socket addresses, dedicated data paths, TOML values, mount types, and public API exposure.
- Make upgrades deterministic by preserving old mount paths, stopping managed services before replacement, and cleaning residual FUSE mounts.
- Build GNU releases on Ubuntu 22.04 and exercise local release installation in WSL.

## One-command installation

After this PR is merged and a new release is published, run:

```bash
curl -fsSL https://raw.githubusercontent.com/gitmono-dev/scorpiofs/main/install.sh | sudo bash
```

The installer interactively asks for:

- Mega/monorepo base URL and Git LFS URL
- data root, FUSE workspace, and local store path
- HTTP listen address
- whether to enable `user_allow_other`
- whether to install and start `scorpiofs.service`

The HTTP API defaults to `127.0.0.1:2725` because it has no authentication.

Recommended inspect-first flow:

```bash
curl -fsSLO https://raw.githubusercontent.com/gitmono-dev/scorpiofs/main/install.sh
less install.sh
sudo bash install.sh
```

### Automated install or reconfiguration

```bash
curl -fsSL https://raw.githubusercontent.com/gitmono-dev/scorpiofs/main/install.sh | \
  sudo bash -s -- --non-interactive --overwrite-config \
    --base-url https://git.rk8s.xuanwu.openatom.cn \
    --lfs-url https://git.rk8s.xuanwu.openatom.cn/lfs \
    --http-addr 127.0.0.1:2725
```

`--overwrite-config` is required to replace an existing `scorpio.toml`; without it, the existing configuration is retained. A non-loopback `--http-addr` additionally requires `--allow-public-api` and must be protected by a firewall or authenticating reverse proxy.

Install without systemd. If `/etc/fuse.conf` already contains `user_allow_other`, keep it unchanged:

```bash
sudo bash install.sh --non-interactive --no-service --no-user-allow-other \
  --base-url https://git.rk8s.xuanwu.openatom.cn \
  --lfs-url https://git.rk8s.xuanwu.openatom.cn/lfs
```

On a host without `user_allow_other`, enable the permission explicitly:

```bash
sudo bash install.sh --non-interactive --no-service --enable-user-allow-other \
  --base-url https://git.rk8s.xuanwu.openatom.cn \
  --lfs-url https://git.rk8s.xuanwu.openatom.cn/lfs
```

Uninstall binaries and the service while keeping configuration and data:

```bash
sudo bash install.sh --uninstall
```

Full options are documented in `README.md`, `deploy/README.md`, and `bash install.sh --help`.

### Upgrade and mount safety

- Only stale `fuse` or `fuse.*` mounts are automatically detached. Non-FUSE mounts at configured roots are rejected and never unmounted.
- Service setup rejects accessible mounts that are not owned by an existing managed unit; stop the user-run daemon and unmount it before retrying.
- Managed upgrades stop the active service before replacing binaries, config, or unit files.
- Old workspace and Antares mount paths are retained and cleaned after the stop, including `--overwrite-config` path changes.
- Installer binaries and the main config must remain outside the workspace and Antares mount roots.

## Verification

- `bash -n install.sh script/test_installer.sh script/test_installer_systemd.sh`
- ShellCheck 0.8.0 on all installer scripts
- `bash script/test_installer.sh`
- WSL Ubuntu 22.04 local HTTP release using real `target/release/scorpio` and `antares`
- Live Mega API check: file tree and latest-commit endpoints return HTTP 200
- SHA256 and binary compatibility preflight
- Generated config validation and overwrite reconfiguration
- Mounted retained-upgrade dry-run prints cleanup without checking simulated host changes
- Non-root retained upgrade against a root-owned mode-0750 config directory
- Non-FUSE inaccessible mount rejection without invoking unmount helpers
- Unmanaged accessible FUSE mount rejection before binary replacement
- Same-user path-changing upgrade: stop old service, clean old mount, install new unit, start service
- Empty data-root migration: infer old root, clean old mount, install new root, start service
- Existing service-user preservation with `--no-service`
- Nested-mount ownership migration rejection
- `/etc/fuse.conf` unchanged and no real systemd unit created during local verification

The current published `v0.4.0` binaries require `GLIBC_2.38`/`GLIBC_2.39` and intentionally fail the compatibility preflight on Ubuntu 22.04. A fresh release after merge is required; future GNU release builds are pinned to Ubuntu 22.04 (glibc 2.35 baseline).

Commits are GPG-signed and include `Signed-off-by` trailers.